### PR TITLE
Update the SciTokens config

### DIFF
--- a/node-check/scitokens
+++ b/node-check/scitokens
@@ -12,46 +12,26 @@ source $add_config_line_source
 ####################
 # SciTokens configuration
 
+# SEC_CREDENTIAL_DIRECTORY=<dir>
+# TOKENS=TRUE
+# SEC_DAEMON_ENCRYPTION=REQUIRED
+
 # First, get the current directory, and create a credentials directory
 credentials_dir=`pwd`/creds
 mkdir -p $credentials_dir
 
 # Set all the configs
-# The monitor periodically looks at a directory to convert the "uberticket"
-# to the SciToken
-cred_mon=`pwd`/condor_credmon
-curl -o $cred_mon http://osg-flock.grid.iu.edu/gwms-extras/condor_credmon
-chmod +x $cred_mon
 
-# SEC_CREDENTIAL_MONITOR = /usr/bin/condor_credmon
-add_config_line_safe SEC_CREDENTIAL_MONITOR "$cred_mon"
-add_condor_vars_line SEC_CREDENTIAL_MONITOR "C" "-" "+" "N" "N" "-"
-
-# SEC_CREDENTIAL_MONITOR_LOG = /etc/batch_credds/credmon.log
-add_config_line_safe SEC_CREDENTIAL_MONITOR_LOG "${credentials_dir}/credmon.log"
-add_condor_vars_line SEC_CREDENTIAL_MONITOR_LOG "C" "-" "+" "N" "N" "-"
-
-# SEC_CREDENTIAL_DIRECTORY = /etc/batch_credds
+# SEC_CREDENTIAL_DIRECTORY = ${credentials_dir} (defined above)
 add_config_line_safe SEC_CREDENTIAL_DIRECTORY "${credentials_dir}"
 add_condor_vars_line SEC_CREDENTIAL_DIRECTORY "C" "-" "+" "N" "N" "-"
 
-# The first argement should the directory to monitor
-# SEC_CREDENTIAL_MONITOR_ARGS = $(SEC_CREDENTIAL_DIRECTORY)
-add_config_line_safe SEC_CREDENTIAL_MONITOR_ARGS "${credentials_dir}"
-add_condor_vars_line SEC_CREDENTIAL_MONITOR_ARGS "C" "-" "+" "N" "N" "-"
+# SEC_CREDENTIAL_DIRECTORY = ${credentials_dir} (defined above)
+add_config_line_safe TOKENS "TRUE"
+add_condor_vars_line TOKENS "C" "-" "+" "N" "N" "-"
 
-# DAEMON_LIST = MASTER, SHARED_PORT, SCHEDD, COLLECTOR, NEGOTIATOR, credD, SEC_CREDENTIAL_MONITOR 
-add_config_line_safe DAEMON_LIST "MASTER, STARTD, SEC_CREDENTIAL_MONITOR"
-add_condor_vars_line DAEMON_LIST "C" "-" "+" "N" "N" "-"
-
-# Also disable shared port - we don't want it on the glideins
-add_config_line_safe USE_SHARED_PORT "False"
-add_condor_vars_line USE_SHARED_PORT "C" "-" "+" "N" "N" "-"
-
-# debugging of security, needed by new rfc fake proxy
-add_config_line_safe MASTER_DEBUG "D_SECURITY"
-add_condor_vars_line MASTER_DEBUG "C" "-" "+" "N" "N" "-"
-add_config_line_safe STARTD_DEBUG "D_SECURITY"
-add_condor_vars_line STARTD_DEBUG "C" "-" "+" "N" "N" "-"
+# SEC_CREDENTIAL_DIRECTORY = ${credentials_dir} (defined above)
+add_config_line_safe SEC_DAEMON_ENCRYPTION "REQUIRED"
+add_condor_vars_line SEC_DAEMON_ENCRYPTION "C" "-" "+" "N" "N" "-"
 
 


### PR DESCRIPTION
SciTokens has changed, and so too should the configuration

- No more daemon that has to run, credd or credmon, on the glidein
- Use the `TOKENS=TRUE` option to tell HTCondor to use the new world order.