### PR TITLE
More condor whitelist variable fixes in job wrappers

### DIFF
--- a/job-wrappers/itb-user-job-wrapper.sh
+++ b/job-wrappers/itb-user-job-wrapper.sh
@@ -344,6 +344,7 @@ if [ "x$OSG_SINGULARITY_REEXEC" = "x" ]; then
                 OSG_SINGULARITY_IMAGE_HUMAN \
                 OSG_SINGULARITY_OUTSIDE_PWD \
                 OSG_SINGULARITY_PATH \
+                OSG_SITE_NAME \
                 OSGVO_PROJECT_NAME \
                 OSGVO_SUBMITTER \
                 OSG_WN_TMP \

--- a/job-wrappers/itb-user-job-wrapper.sh
+++ b/job-wrappers/itb-user-job-wrapper.sh
@@ -325,6 +325,7 @@ if [ "x$OSG_SINGULARITY_REEXEC" = "x" ]; then
                 _CONDOR_MACHINE_AD \
                 _CONDOR_SCRATCH_DIR \
                 _CONDOR_WRAPPER_ERROR_FILE \
+		CONDOR_PARENT_ID \
                 GLIDEIN_Client \
                 GLIDEIN_CMSSite \
                 GLIDEIN_Country \
@@ -417,7 +418,8 @@ else
     unset TEMP
     unset X509_CERT_DIR
     for key in X509_USER_PROXY X509_USER_CERT \
-               _CONDOR_CREDS _CONDOR_MACHINE_AD _CONDOR_JOB_AD \
+               _CONDOR_CREDS _CONDOR_MACHINE_AD \
+               _CONDOR_EXECUTE _CONDOR_JOB_AD \
                _CONDOR_SCRATCH_DIR _CONDOR_CHIRP_CONFIG _CONDOR_JOB_IWD \
                OSG_WN_TMP ; do
         eval val="\$$key"

--- a/job-wrappers/user-job-wrapper.sh
+++ b/job-wrappers/user-job-wrapper.sh
@@ -371,6 +371,8 @@ if [ "x$OSG_SINGULARITY_REEXEC" = "x" ]; then
             OSG_SINGULARITY_ENVVARS="OSG_SINGULARITY_REEXEC \
                 _CHIRP_DELAYED_UPDATE_PREFIX \
                 CONDOR_PARENT_ID \
+                GLIDEIN_ResourceName \
+                GLIDEIN_Site \
                 HAS_SINGULARITY \
                 http_proxy \
                 InitializeModulesEnv \
@@ -384,6 +386,7 @@ if [ "x$OSG_SINGULARITY_REEXEC" = "x" ]; then
                 OSG_SINGULARITY_IMAGE_HUMAN \
                 OSG_SINGULARITY_OUTSIDE_PWD \
                 OSG_SINGULARITY_PATH \
+                OSG_SITE_NAME \
                 OSGVO_PROJECT_NAME \
                 OSGVO_SUBMITTER \
                 OSG_WN_TMP \

--- a/job-wrappers/user-job-wrapper.sh
+++ b/job-wrappers/user-job-wrapper.sh
@@ -370,6 +370,7 @@ if [ "x$OSG_SINGULARITY_REEXEC" = "x" ]; then
 
             OSG_SINGULARITY_ENVVARS="OSG_SINGULARITY_REEXEC \
                 _CHIRP_DELAYED_UPDATE_PREFIX \
+                CONDOR_PARENT_ID \
                 HAS_SINGULARITY \
                 http_proxy \
                 InitializeModulesEnv \
@@ -485,7 +486,8 @@ else
     unset TEMP
     unset X509_CERT_DIR
     for key in X509_USER_PROXY X509_USER_CERT \
-               _CONDOR_CREDS _CONDOR_MACHINE_AD _CONDOR_JOB_AD \
+               _CONDOR_CREDS _CONDOR_MACHINE_AD \ 
+               _CONDOR_EXECUTE _CONDOR_JOB_AD \
                _CONDOR_SCRATCH_DIR _CONDOR_CHIRP_CONFIG _CONDOR_JOB_IWD \
                OSG_WN_TMP ; do
         eval val="\$$key"


### PR DESCRIPTION
This patch adds `CONDOR_PARENT_ID` to the list of variables that are whitelisted and propagated through to a singularity container if the container is invoked with `+SingularityCleanEnv=True`, and also patches references to the Condor working directory in `_CONDOR_EXECUTE` to the path under which that directory is mounted inside the container. These changes are made in both `user-job-wrapper.sh` and `itb-user-job-wrapper.sh`.