### PR TITLE
Add guard around load of stashcp from modules in case in container

### DIFF
--- a/job-wrappers/user-job-wrapper.sh
+++ b/job-wrappers/user-job-wrapper.sh
@@ -568,7 +568,9 @@ fi
 
 function setup_stashcp {
   # keep the user job output clean
-  module load stashcache >/dev/null 2>&1 || module load stashcp >/dev/null 2>&1
+  if ! which stashcp >/dev/null 2>&1; then
+      module load stashcache >/dev/null 2>&1 || module load stashcp >/dev/null 2>&1
+  fi
 
   # we need xrootd, which is available both in the OSG software stack
   # as well as modules - use the system one by default

--- a/job-wrappers/user-job-wrapper.sh
+++ b/job-wrappers/user-job-wrapper.sh
@@ -567,22 +567,15 @@ fi
 #
 
 function setup_stashcp {
-  # keep the user job output clean
+  # if we do not have stashcp in the path, load stashcache and xrootd from modules
   if ! which stashcp >/dev/null 2>&1; then
       module load stashcache >/dev/null 2>&1 || module load stashcp >/dev/null 2>&1
-  fi
-
-  # we need xrootd, which is available both in the OSG software stack
-  # as well as modules - use the system one by default
-  if ! which xrdcp >/dev/null 2>&1; then
       module load xrootd >/dev/null 2>&1
+      # Determine XRootD plugin directory.
+      # in lieu of a MODULE_<name>_BASE from lmod, this will do:
+      export MODULE_XROOTD_BASE=$(which xrdcp | sed -e 's,/bin/.*,,')
+      export XRD_PLUGINCONFDIR=$MODULE_XROOTD_BASE/etc/xrootd/client.plugins.d
   fi
- 
-  # Determine XRootD plugin directory.
-  # in lieu of a MODULE_<name>_BASE from lmod, this will do:
-  export MODULE_XROOTD_BASE=$(which xrdcp | sed -e 's,/bin/.*,,')
-  export XRD_PLUGINCONFDIR=$MODULE_XROOTD_BASE/etc/xrootd/client.plugins.d
- 
 }
  
 # Check for PosixStashCache first


### PR DESCRIPTION
Though I understand that it has been rare for `stashcp` to be present on worker nodes, this PR adds a guard that will only try to load the stashcp modules if that executable is not on the present path, similar to the guard around the load of the XRootD modules a few lines further down.  This way, someone can request stashcache and not have any modules loaded (thus potentially adding things to their environment) **_if_** they have added `stashcp` into their container (as, for example, PyCBC now does by adding the `osg-wn-client` package to the container).