### PR TITLE
Adding a new submit host for VERITAS

### DIFF
--- a/flock.opensciencegrid.org/flocking-hosts.yml
+++ b/flock.opensciencegrid.org/flocking-hosts.yml
@@ -90,6 +90,12 @@ login05.osgconnect.net:
   dn: /DC=org/DC=incommon/C=US/ST=IL/L=Chicago/O=University of Chicago/OU=IT Services - Self Enrollment/CN=condor-flocking-cert.grid.uchicago.edu
 # doesn't really have a DN, but need it for gwms to pick up the host
 
+login.veritas.ci-connect.net:
+  admin: Lincoln Bryant <lincolnb@uchicago.edu>
+  site: OSGConnect
+  dn: /DC=org/DC=incommon/C=US/ST=IL/L=Chicago/O=University of Chicago/OU=IT Services - Self Enrollment/CN=condor-flocking-cert.grid.uchicago.edu
+# doesn't really have a DN, but need it for gwms to pick up the host
+
 duke-login.osgconnect.net:
   admin: Lincoln Bryant <lincolnb@uchicago.edu>
   site: OSGConnect


### PR DESCRIPTION
Adding a new submit host for VERITAS, this node is also using token-based auth.