### PR TITLE
Add uclhc-2.ps.uci.edu to flocking-hosts.yml

### DIFF
--- a/flock.opensciencegrid.org/flocking-hosts.yml
+++ b/flock.opensciencegrid.org/flocking-hosts.yml
@@ -277,6 +277,11 @@ uclhc-1.ps.uci.edu:
   site: UCI
   dn: /DC=org/DC=incommon/C=US/ST=CA/L=Irvine/O=University of California/OU=School of Physical Sciences/CN=uclhc-1.ps.uci.edu
 
+uclhc-2.ps.uci.edu:
+  admin: Nathan Crawford <nrcrawfo@uci.edu>
+  site: UCI
+  dn: /DC=org/DC=incommon/C=US/ST=California/L=Irvine/O=University of California, Irvine/OU=School of Physical Sciences/CN=uclhc-2.ps.uci.edu
+
 ### SDSC GRAPLeR ###
 
 rocks-186.sdsc.edu:


### PR DESCRIPTION
Adding new host for UCI ATLAS on Greenplanet (UC Irvine School of Physical Sciences cluster), per @efajardo 