### PR TITLE
Enable Schedd AuditLog by default in osg-flock (SOFTWARE-4390)

### DIFF
--- a/rpm/80-osg-flocking.conf
+++ b/rpm/80-osg-flocking.conf
@@ -55,3 +55,9 @@ if version < 8.9.6
 
 endif
 
+# Enable the audit log so admins can track Schedd usage (SOFTWARE-4390)
+SCHEDD_AUDIT_LOG = $(LOG)/AuditLog
+SCHEDD_DEBUG = D_AUDIT
+MAX_SCHEDD_AUDIT_LOG = 1d
+MAX_NUM_SCHEDD_AUDIT_LOG = 90
+


### PR DESCRIPTION
Can you guys think of any reason we shouldn't do this? I just picked 90d to match the CE

https://opensciencegrid.atlassian.net/browse/SOFTWARE-4390