### PR TITLE
Add OSG_PROJECT_NAME and OSG_PROJECT_RESTRICTION

### DIFF
--- a/node-check/osgvo-advertise-base
+++ b/node-check/osgvo-advertise-base
@@ -386,6 +386,22 @@ fi
 advertise XCACHE_CLOSEST "$XCACHE_CLOSEST" "S"
 advertise XCACHE_CLOSEST_RTT "$XCACHE_CLOSEST_RTT" "C"
 
+
+###########################################################
+# Project restriction
+if [[ -n $GLIDEIN_PROJECT_ID ]]; then
+    info "GLIDEIN_PROJECT_ID=$GLIDEIN_PROJECT_ID"
+    project_name=$(awk -F, '{print $NF}' <<<$GLIDEIN_PROJECT_ID)
+
+    if [[ -n $project_name ]]; then
+        advertise OSG_PROJECT_NAME "$project_name" "S"
+        advertise OSG_PROJECT_RESTRICTION "ProjectName =?= OSG_PROJECT_NAME" "C"
+    fi
+else
+    info "GLIDEIN_PROJECT_ID is unset"
+fi
+
+
 ##################
 rm -f $PID_FILE
 info "All done - time to do some real work!"


### PR DESCRIPTION
SOFTWARE-4580; if GLIDEIN_PROJECT_ID is available, advertise a new OSG_PROJECT_NAME attribute based on it, and add an OSG_PROJECT_RESTRICTION condition so only jobs with a matching ProjectName can run there.

