### PR TITLE
Update 95_negotiator_osgflockgit.config

### DIFF
--- a/flock.opensciencegrid.org/htcondor/config.d/95_negotiator_osgflockgit.config
+++ b/flock.opensciencegrid.org/htcondor/config.d/95_negotiator_osgflockgit.config
@@ -55,8 +55,12 @@ VALID_SPOOL_FILES=$(VALID_SPOOL_FILES), negotiator_allocated
 DAEMON_LIST = $(DAEMON_LIST), NEGOTIATOR_ALLOCATED
 DC_DAEMON_LIST =+ NEGOTIATOR_ALLOCATED
 
+# Per Miron 8/11/21, pruning out slowest machines only costs 3% of total OSPool MIPS
+# and allows us to make better committment to our users about job runtime.
+ENOUGH_MIPS = (Mips > 11800)
+
 # Make sure each negotiator considers the right set of slots.
-NEGOTIATOR_SLOT_CONSTRAINT = User_Allocated_Resource =!= True && GLIDEIN_Site =!= "Nebraska" && JobStarts < 1000
+NEGOTIATOR_SLOT_CONSTRAINT = $(ENOUGH_MIPS) && User_Allocated_Resource =!= True && GLIDEIN_Site =!= "Nebraska" && JobStarts < 1000 
 
 NEGOTIATOR_ALLOCATED.NEGOTIATOR_SLOT_CONSTRAINT = User_Allocated_Resource =?= True 
 


### PR DESCRIPTION
As per Miron's email, the main OSPool negotiator should ignore machines whose startd-computed Mips is below 11,800.  This removes roughly 3% of the total mips of the pool, but let's users have much tighter constraints on their job runtime.  Eventually, this will let us establish tighter upper bounds on job runtimes, without worrying about getting stuck on slow machines.  e.g. "You must have a least this many mips to be part of the OSPool"