### PR TITLE
Add a two-part project_id by hand to the Stampede2 entries

### DIFF
--- a/flock.opensciencegrid.org/frontend-template.xml
+++ b/flock.opensciencegrid.org/frontend-template.xml
@@ -1013,7 +1013,8 @@
          </match>
          <security>
             <credentials>
-               <credential absfname="/etc/grid-security/gwms-frontend/osg-pilot.proxy" project_id="TG-DDM160003" security_class="frontend" trust_domain="grid" type="grid_proxy+project_id"/>
+                <!-- project_id: TG-CHE200122 is allowed to use the allocation TG-DDM160003 on Stampede2 -->
+               <credential absfname="/etc/grid-security/gwms-frontend/osg-pilot.proxy" project_id="TG-DDM160003,TG-CHE200122" security_class="frontend" trust_domain="grid" type="grid_proxy+project_id"/>
             </credentials>
          </security>
          <attrs>
@@ -1068,7 +1069,8 @@
          </match>
          <security>
             <credentials>
-               <credential absfname="/etc/grid-security/gwms-frontend/osg-pilot.proxy" project_id="cwr109" security_class="frontend" trust_domain="grid" type="grid_proxy+project_id"/>
+                <!-- project_id: UTAustin_Zimmerman's Stampede2 allocation is GravSearches -->
+               <credential absfname="/etc/grid-security/gwms-frontend/osg-pilot.proxy" project_id="GravSearches,UTAustin_Zimmerman" security_class="frontend" trust_domain="grid" type="grid_proxy+project_id"/>
             </credentials>
          </security>
          <attrs>


### PR DESCRIPTION
This is two comma-separated values, the first one being the local allocation ID
on the resource, and the second is the OSG project name.

The CE job route will split these out and use them.

This will be automatically added by the frontend once SOFTWARE-4565 is ready;
in the meantime, set it by hand so we can test the job routes.
