### PR TITLE
Test using topology_match_policy.py for alloc-Bridges2-GPU-TG-CHE200122

### DIFF
--- a/flock.opensciencegrid.org/frontend-template.xml
+++ b/flock.opensciencegrid.org/frontend-template.xml
@@ -887,14 +887,17 @@
             <running_glideins_per_entry max="20" min="0" relative_to_queue="5.0"/>
             <running_glideins_total curb="19" max="20"/>
          </config>
-         <match match_expr="True" start_expr='(TARGET.projectName =?= "TG-CHE200122") &amp;&amp; ( (TARGET.WantsXSEDE == True) || (isString(TARGET.Desired_Allocations) &amp;&amp; stringListIMember("Bridges2", TARGET.Desired_Allocations)) ) &amp;&amp; (TARGET.RequestGPUs &gt; 0) &amp;&amp;(TARGET.ITB_Sites =!= True)'>
+         <match
+             policy_file="/opt/git/flock.opensciencegrid.org/topology_match_policy.py"
+             match_expr="True"
+             start_expr='(TARGET.projectName =?= "TG-CHE200122") &amp;&amp; ( (TARGET.WantsXSEDE == True) || (isString(TARGET.Desired_Allocations) &amp;&amp; stringListIMember("Bridges2", TARGET.Desired_Allocations)) ) &amp;&amp; (TARGET.RequestGPUs &gt; 0) &amp;&amp;(TARGET.ITB_Sites =!= True)'>
             <factory query_expr='FactoryType == "production" &amp;&amp; stringListMember("OSG_ZUBATYUK_GPU", GLIDEIN_Supported_VOs)'>
                <match_attrs>
                </match_attrs>
                <collectors>
                </collectors>
             </factory>
-            <job query_expr='(projectName=?="TG-CHE200122") &amp;&amp; ( (WantsXSEDE == True) || (isString(Desired_Allocations) &amp;&amp; stringListIMember("Bridges2", Desired_Allocations)) ) &amp;&amp; (RequestGPUs &gt; 0)'>
+            <job query_expr='( (WantsXSEDE == True) || (isString(Desired_Allocations) &amp;&amp; stringListIMember("Bridges2", Desired_Allocations)) ) &amp;&amp; (RequestGPUs &gt; 0)'>
                <match_attrs>
                </match_attrs>
                <schedds>


### PR DESCRIPTION
Using topology_match_policy.py as the policy_file in a <match> will check the job's ProjectName against the entry's GLIDEIN_ResourceName and reject jobs from projects that aren't allowed to use that resource (in topology).

This should let us get rid of the explicit ProjectName check in the job query_expr. (I think it can also let us get rid of the GLIDEIN_Supported_VOs check in the factory_expr too but I haven't tested that.)