### PR TITLE
Add group for SKX jobs on Stampede2 for UTAustin_Zimmerman

### DIFF
--- a/flock.opensciencegrid.org/frontend-template.xml
+++ b/flock.opensciencegrid.org/frontend-template.xml
@@ -1005,14 +1005,14 @@
          <match
              policy_file="/opt/git/flock.opensciencegrid.org/topology_match_policy.py"
              match_expr="True"
-             start_expr='(OSG_PROJECT_RESTRICTION) &amp;&amp; (isString(TARGET.Desired_Allocations) &amp;&amp; stringListIMember("Stampede2", TARGET.Desired_Allocations)) &amp;&amp; (TARGET.ITB_Sites =!= True)'>
-            <factory query_expr='FactoryType == "production" &amp;&amp; stringListMember("OSG_UTAustin_Zimmerman", GLIDEIN_Supported_VOs)'>
+             start_expr='(OSG_PROJECT_RESTRICTION) &amp;&amp; (isString(TARGET.Desired_Allocations) &amp;&amp; stringListIMember("Stampede2", TARGET.Desired_Allocations)) &amp;&amp; (TARGET.ITB_Sites =!= True) &amp;&amp; ((TARGET.alloc_Stampede2_queue ?: "normal") =?= "normal")'>
+            <factory query_expr='FactoryType == "production" &amp;&amp; stringListMember("OSG_UTAustin_Zimmerman", GLIDEIN_Supported_VOs) &amp;&amp; ((GLIDEIN_BatchQueue ?: "normal") =?= "normal")'>
                <match_attrs>
                </match_attrs>
                <collectors>
                </collectors>
             </factory>
-            <job query_expr='(projectName=?="UTAustin_Zimmerman") &amp;&amp; (isString(Desired_Allocations) &amp;&amp; stringListIMember("Stampede2", Desired_Allocations)) &amp;&amp; (isUndefined(RequestGPUs) || RequestGPUs == 0)'>
+            <job query_expr='(projectName=?="UTAustin_Zimmerman") &amp;&amp; (isString(Desired_Allocations) &amp;&amp; stringListIMember("Stampede2", Desired_Allocations)) &amp;&amp; (isUndefined(RequestGPUs) || RequestGPUs == 0) &amp;&amp; ((alloc_Stampede2_queue ?: "normal") =?= "normal")'>
                <match_attrs>
                </match_attrs>
                <schedds>
@@ -1065,14 +1065,14 @@
          <match
              policy_file="/opt/git/flock.opensciencegrid.org/topology_match_policy.py"
              match_expr="True"
-             start_expr='(OSG_PROJECT_RESTRICTION) &amp;&amp; (isString(TARGET.Desired_Allocations) &amp;&amp; stringListIMember("Stampede2", TARGET.Desired_Allocations)) &amp;&amp; (TARGET.ITB_Sites =!= True)'>
-            <factory query_expr='FactoryType == "production" &amp;&amp; stringListMember("OSG_UTAustin_Zimmerman", GLIDEIN_Supported_VOs)'>
+             start_expr='(OSG_PROJECT_RESTRICTION) &amp;&amp; (isString(TARGET.Desired_Allocations) &amp;&amp; stringListIMember("Stampede2", TARGET.Desired_Allocations)) &amp;&amp; (TARGET.ITB_Sites =!= True) &amp;&amp; ((TARGET.alloc_Stampede2_queue ?: "normal") =?= "skx-normal")'>
+            <factory query_expr='FactoryType == "production" &amp;&amp; stringListMember("OSG_UTAustin_Zimmerman", GLIDEIN_Supported_VOs) &amp;&amp; ((GLIDEIN_BatchQueue ?: "normal") =?= "skx-normal")'>
                <match_attrs>
                </match_attrs>
                <collectors>
                </collectors>
             </factory>
-            <job query_expr='(projectName=?="UTAustin_Zimmerman") &amp;&amp; (isString(Desired_Allocations) &amp;&amp; stringListIMember("Stampede2", Desired_Allocations)) &amp;&amp; (isUndefined(RequestGPUs) || RequestGPUs == 0)'>
+            <job query_expr='(projectName=?="UTAustin_Zimmerman") &amp;&amp; (isString(Desired_Allocations) &amp;&amp; stringListIMember("Stampede2", Desired_Allocations)) &amp;&amp; (isUndefined(RequestGPUs) || RequestGPUs == 0) &amp;&amp; ((alloc_Stampede2_queue ?: "normal") =?= "skx-normal")'>
                <match_attrs>
                </match_attrs>
                <schedds>

--- a/flock.opensciencegrid.org/frontend-template.xml
+++ b/flock.opensciencegrid.org/frontend-template.xml
@@ -990,7 +990,68 @@
             </file>
          </files>
       </group>
+
       <group name="alloc-Stampede2-CPU-UTAustin_Zimmerman" enabled="True">
+         <config ignore_down_entries="">
+            <glideins_removal margin="0" requests_tracking="False" type="NO" wait="0"/>
+            <idle_glideins_lifetime max="864000"/>
+            <idle_glideins_per_entry max="50" reserve="1"/>
+            <idle_vms_per_entry curb="50" max="50"/>
+            <idle_vms_total curb="50" max="50"/>
+            <processing_workers matchmakers="3"/>
+            <running_glideins_per_entry max="5000" min="0" relative_to_queue="5.0"/>
+            <running_glideins_total curb="5000" max="5000"/>
+         </config>
+         <match
+             policy_file="/opt/git/flock.opensciencegrid.org/topology_match_policy.py"
+             match_expr="True"
+             start_expr='(OSG_PROJECT_RESTRICTION) &amp;&amp; (isString(TARGET.Desired_Allocations) &amp;&amp; stringListIMember("Stampede2", TARGET.Desired_Allocations)) &amp;&amp; (TARGET.ITB_Sites =!= True)'>
+            <factory query_expr='FactoryType == "production" &amp;&amp; stringListMember("OSG_UTAustin_Zimmerman", GLIDEIN_Supported_VOs)'>
+               <match_attrs>
+               </match_attrs>
+               <collectors>
+               </collectors>
+            </factory>
+            <job query_expr='(projectName=?="UTAustin_Zimmerman") &amp;&amp; (isString(Desired_Allocations) &amp;&amp; stringListIMember("Stampede2", Desired_Allocations)) &amp;&amp; (isUndefined(RequestGPUs) || RequestGPUs == 0)'>
+               <match_attrs>
+               </match_attrs>
+               <schedds>
+                {{{schedd_blob}}}
+               </schedds>
+            </job>
+         </match>
+         <security>
+            <credentials>
+                <!-- project_id: UTAustin_Zimmerman's Stampede2 allocation is GravSearches -->
+               <credential absfname="/etc/grid-security/gwms-frontend/osg-pilot.proxy" project_id="GravSearches,UTAustin_Zimmerman" security_class="frontend" trust_domain="grid" type="grid_proxy+project_id"/>
+            </credentials>
+         </security>
+         <attrs>
+            <attr name="GLIDECLIENT_OSG_VO" glidein_publish="True" job_publish="True" parameter="False" type="string" value="OSG"/>
+            <attr name="GLIDEIN_Glexec_Use" glidein_publish="True" job_publish="True" parameter="True" type="string" value="NEVER"/>
+            <attr name="SLOTS_LAYOUT" glidein_publish="True" job_publish="True" parameter="False" type="string" value="partitionable"/>
+            <attr name="GLIDEIN_Singularity_Use" glidein_publish="True" job_publish="False" parameter="True" type="string" value="PREFERRED"/>
+            <attr name="User_Allocated_Resource" glidein_publish="True" job_publish="False" parameter="True" type="expr" value="True"/>
+            <attr name="SINGULARITY_IMAGE_RESTRICTIONS" glidein_publish="True" job_publish="False" parameter="True" type="string" value="none"/>
+            <attr name="OSG_SINGULARITY_BINARY" glidein_publish="True" job_publish="True" parameter="True" type="string" value="/opt/apps/tacc-singularity/3.7.2/bin/singularity"/>
+         </attrs>
+         <files>
+            <file absfname="/opt/git/node-check/osgvo-advertise-base" after_entry="True" const="True" executable="True" period="180" prefix="NOPREFIX" untar="False" wrapper="False">
+               <untar_options cond_attr="TRUE"/>
+            </file>
+            <file absfname="/opt/git/node-check/osgvo-advertise-userenv" type="run:singularity" after_entry="True" const="True" executable="True" prefix="NOPREFIX" untar="False" wrapper="False">
+               <untar_options cond_attr="TRUE"/>
+            </file>
+            <file absfname="/opt/git/node-check/osgvo-default-image" after_entry="False" const="True" executable="True" period="0" prefix="NOPREFIX" untar="False" wrapper="False">
+               <untar_options cond_attr="TRUE"/>
+            </file>
+            <file absfname="/opt/git/job-wrappers/default_singularity_wrapper.sh" after_entry="True" const="True" executable="False" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="True">
+               <untar_options cond_attr="TRUE"/>
+            </file>
+         </files>
+      </group>
+
+      <group name="alloc-Stampede2-CPU-SKX-UTAustin_Zimmerman" enabled="True">
          <config ignore_down_entries="">
             <glideins_removal margin="0" requests_tracking="False" type="NO" wait="0"/>
             <idle_glideins_lifetime max="864000"/>

--- a/flock.opensciencegrid.org/frontend-template.xml
+++ b/flock.opensciencegrid.org/frontend-template.xml
@@ -1055,9 +1055,9 @@
          <config ignore_down_entries="">
             <glideins_removal margin="0" requests_tracking="False" type="NO" wait="0"/>
             <idle_glideins_lifetime max="864000"/>
-            <idle_glideins_per_entry max="50" reserve="1"/>
-            <idle_vms_per_entry curb="50" max="50"/>
-            <idle_vms_total curb="50" max="50"/>
+            <idle_glideins_per_entry max="25" reserve="1"/>
+            <idle_vms_per_entry curb="25" max="25"/>
+            <idle_vms_total curb="25" max="25"/>
             <processing_workers matchmakers="3"/>
             <running_glideins_per_entry max="5000" min="0" relative_to_queue="5.0"/>
             <running_glideins_total curb="5000" max="5000"/>


### PR DESCRIPTION
- Create a copy of alloc-Stampede2-CPU-UTAustin_Zimmerman that uses the skx-normal queue
- SKX allows fewer jobs in the queue
- Distinguish between the two types of Stampede2 jobs with alloc_Stampede2_queue (for jobs) and GLIDEIN_BatchQueue (for factory entries)
