### PR TITLE
Add match expression logic to top-level of frontend.

### DIFF
--- a/flock.opensciencegrid.org/frontend-template.xml
+++ b/flock.opensciencegrid.org/frontend-template.xml
@@ -16,9 +16,34 @@
          <process_log backup_count="1" compression="" extension="dbg" max_days="7.0" max_mbytes="100.0" min_days="1.0" msg_types="DEBUG"/>
       </process_logs>
    </log_retention>
-   <match match_expr="True" start_expr='(isUndefined(MY.OSG_NODE_VALIDATED) || MY.OSG_NODE_VALIDATED) &amp;&amp;
+   <match match_expr='(
+            (glidein["attrs"].get("GLIDEIN_CPUS", "1")[0] in ["a", "s", "n"])
+            or
+            job.get("RequestCpus",1) &lt;= int(glidein["attrs"].get("GLIDEIN_CPUS", "1"))
+        )
+        and
+        (
+            (job.get("DESIRED_Sites","nosite")=="nosite")
+            or
+            (glidein["attrs"]["GLIDEIN_Site"] in job.get("DESIRED_Sites","nosite").split(","))
+        )
+        and
+        (
+            (job.get("UNDESIRED_Sites","nosite")=="nosite")
+            or
+            (glidein["attrs"]["GLIDEIN_Site"] not in job.get("UNDESIRED_Sites","nosite").split(","))
+        )
+        and
+        (
+            int(glidein["attrs"]["GLIDEIN_MaxMemMBs"] or 0) == 0
+            or
+            job.get("RequestMemory", 1024) &lt;= int(glidein["attrs"]["GLIDEIN_MaxMemMBs"] or 0)
+        )'
+                            start_expr='(isUndefined(MY.OSG_NODE_VALIDATED) || MY.OSG_NODE_VALIDATED) &amp;&amp;
                                         (isUndefined(IsBlackHole) || IsBlackHole == False) &amp;&amp;
                                         (isUndefined(HasExcessiveLoad) || HasExcessiveLoad == False) &amp;&amp;
+                                        ((DESIRED_Sites=?=undefined) || stringListMember(GLIDEIN_Site,DESIRED_Sites,",")) &amp;&amp;
+                                        (UNDESIRED_Sites=?=undefined || !stringListMember(GLIDEIN_Site,UNDESIRED_Sites,",")) &amp;&amp;
                                         (isUndefined(TARGET.ProjectName) != True &amp;&amp; TARGET.ProjectName != "") &amp;&amp;
                                         (regexp("CancerComputer", GLIDEIN_ResourceName) =!= True || stringListMember(TARGET.ProjectName, "SBGrid,SPLINTER,TG-MCB130135,BioGraph,swipnanobio,SINGE,SSGAforCSP,sweeps,TG-MCB190026,PNGtemplate,PainDrugs", ",") || regexp("^COVID19", TARGET.ProjectName)) &amp;&amp;
                                         (isUndefined(WantsStashCvmfs) ||
@@ -29,6 +54,9 @@
                                         '>
       <factory query_expr="True">
          <match_attrs>
+            <match_attr name="GLIDEIN_MaxMemMBs" type="int"/>
+            <match_attr name="GLIDEIN_Site" type="string"/>
+	    <match_attr name="GLIDEIN_CPUS" type="string"/>
          </match_attrs>
          <collectors>
             <collector DN="/DC=org/DC=incommon/C=US/ST=Wisconsin/L=Madison/O=University of Wisconsin-Madison/OU=OCIS/CN=gfactory-2.opensciencegrid.org" comment="Open Science Grid Factory 2" factory_identity="gfactory@gfactory-2.opensciencegrid.org" my_identity="feosgflock@gfactory-2.opensciencegrid.org" node="gfactory-2.opensciencegrid.org"/>
@@ -36,6 +64,10 @@
       </factory>
       <job comment="Define job constraint and schedds globally for simplicity" query_expr="(JobUniverse==5)&amp;&amp;(GLIDEIN_Is_Monitor =!= TRUE)&amp;&amp;(JOB_Is_Monitor =!= TRUE)">
          <match_attrs>
+             <match_attr name="UNDESIRED_Sites" type="string"/>
+             <match_attr name="DESIRED_Sites" type="string"/>
+             <match_attr name="RequestMemory" type="int"/>
+	     <match_attr name="RequestCpus" type="int"/>
          </match_attrs>
          <schedds>
          </schedds>
@@ -346,12 +378,10 @@
             <running_glideins_per_entry max="1" min="0" relative_to_queue="5.0"/>
             <running_glideins_total curb="80" max="100"/>
          </config>
-         <match match_expr='((glidein["attrs"]["GLIDEIN_Site"] in job.get("DESIRED_Sites","").split(",")) or (job.get("DESIRED_Sites","nosite")=="nosite"))'
-                start_expr='(TARGET.ITB_Sites =?= True) &amp;&amp;
-                            ((DESIRED_Sites=?=undefined) || stringListMember(GLIDEIN_Site,DESIRED_Sites,","))'>
+         <match match_expr='True'
+                start_expr='(TARGET.ITB_Sites =?= True)'>
             <factory query_expr='FactoryType == "OSG-ITB" &amp;&amp; stringListMember("OSGVO", GLIDEIN_Supported_VOs)'>
                <match_attrs>
-                  <match_attr name="GLIDEIN_Site" type="string"/>
                </match_attrs>
                <collectors>
                   <collector DN="/DC=org/DC=incommon/C=US/ST=Wisconsin/L=Madison/O=University of Wisconsin-Madison/OU=OCIS/CN=gfactory-itb-1.opensciencegrid.org" factory_identity="gfactory@gfactory-itb-1.opensciencegrid.org" my_identity="feosgflock@gfactory-itb-1.opensciencegrid.org" node="gfactory-itb-1.opensciencegrid.org"/>
@@ -359,7 +389,6 @@
             </factory>
             <job query_expr="(ITB_Sites =?= True)">
                <match_attrs>
-                  <match_attr name="DESIRED_Sites" type="string"/>
                </match_attrs>
                <schedds>
                 {{{schedd_blob}}}
@@ -472,7 +501,7 @@
             <running_glideins_per_entry max="60000" min="0" relative_to_queue="5.0"/>
             <running_glideins_total curb="57000" max="60000"/>
          </config>
-         <match match_expr='((glidein["attrs"]["GLIDEIN_Site"] in job.get("DESIRED_Sites","").split(",")) or (job.get("DESIRED_Sites","nosite")=="nosite"))'
+         <match match_expr='True'
                 start_expr='(((DESIRED_Sites=?=undefined) || stringListMember(GLIDEIN_Site,DESIRED_Sites,",")) &amp;&amp;
                              (UNDESIRED_Sites=?=undefined || !stringListMember(GLIDEIN_Site,UNDESIRED_Sites,",")) &amp;&amp;
                              (TARGET.ProjectName =!= "IBN130001-Plus") &amp;&amp;
@@ -484,14 +513,12 @@
                                  !StringListMember(GLIDEIN_ResourceName, "OSG_IN_IUCAA_SARATHI") &amp;&amp;
                                  (GLIDEIN_REQUIRE_VOMS =!= "True")'>
                <match_attrs>
-                  <match_attr name="GLIDEIN_Site" type="string"/>
                </match_attrs>
                <collectors>
                </collectors>
             </factory>
             <job query_expr="isUndefined(RequiresWholeMachine) &amp;&amp; (ITB_Sites =!= True) &amp;&amp; (ITB_Factory =!= True) &amp;&amp; isUndefined(RequiresLongWalltime) &amp;&amp; isUndefined(RequiresBigMem) &amp;&amp; (isUndefined(RequestGPUs) || RequestGPUs == 0)">
                <match_attrs>
-                  <match_attr name="DESIRED_Sites" type="string"/>
                </match_attrs>
                <schedds>
                 {{{schedd_blob}}}
@@ -535,7 +562,7 @@
             <running_glideins_per_entry max="1000" min="0" relative_to_queue="5.0"/>
             <running_glideins_total curb="950" max="1000"/>
          </config>
-         <match match_expr='((glidein["attrs"]["GLIDEIN_Site"] in job.get("DESIRED_Sites","").split(",")) or (job.get("DESIRED_Sites","nosite")=="nosite"))'
+         <match match_expr='True'
                 start_expr='(((DESIRED_Sites=?=undeined) || stringListMember(GLIDEIN_Site,DESIRED_Sites,",")) &amp;&amp;
                              (UNDESIRED_Sites=?=undefined || !stringListMember(GLIDEIN_Site,UNDESIRED_Sites,",")) &amp;&amp;
                              (TARGET.ProjectName =!= "IBN130001-Plus") &amp;&amp;
@@ -547,14 +574,12 @@
                                  (GLIDEIN_REQUIRE_VOMS =!= "True") &amp;&amp; 
                                  (GLIDEIN_ResourceName =!= "FNAL_FERMIGRID") &amp;&amp; (GLIDEIN_ResourceName =!= "GPGrid") &amp;&amp; (GLIDEIN_ResourceName =!= "USCMS-FNAL-WC1")'>
                <match_attrs>
-                  <match_attr name="GLIDEIN_Site" type="string"/>
                </match_attrs>
                <collectors>
                </collectors>
             </factory>
             <job query_expr="isUndefined(RequiresWholeMachine) &amp;&amp; (ITB_Sites =!= True) &amp;&amp; (ITB_Factory =!= True) &amp;&amp; isUndefined(RequiresLongWalltime) &amp;&amp; isUndefined(RequiresBigMem) &amp;&amp; (isUndefined(RequestGPUs) || RequestGPUs == 0)">
                <match_attrs>
-                  <match_attr name="DESIRED_Sites" type="string"/>
                </match_attrs>
                <schedds>
                 {{{schedd_blob}}}


### PR DESCRIPTION
As we're low in jobs, we're seeing a lot of requested glideins that are
not matchable, particularly because the remaining jobs are high-memory
(and they're causing pilots to be requested from low-memory slots).

Copied over the match expressions from CHTC.  Note they are python3
compatible and have some funkiness like:

```
int(glidein["attrs"]["GLIDEIN_MaxMemMBs"] or 0) == 0
```

This is to protect us from the fact the factory isn't consistent in
typing and sometimes sets attributes as strings and other times as
integers.

With this, a job can avoid a site by setting UNDESIRED_Sites; this
is significantly better than using the Requirements expression (as
glideinWMS understands this as well).