### PR TITLE
Use SIF files instead of unpacking everything into sandbox

### DIFF
--- a/job-wrappers/itb-default_singularity_wrapper.sh
+++ b/job-wrappers/itb-default_singularity_wrapper.sh
@@ -194,6 +194,9 @@ download_or_build_singularity_image () {
     # if it is 0, verify that the image is indeed on CVMFS
     # if it is 1, transform the image to a form and try downloaded it from our services
 
+    # In addition, UNPACK_SIF determines whether a downloaded SIF image is
+    # expanded into the sandbox format (1) or used as-is (0).
+
     if [ "x$ALLOW_NONCVMFS_IMAGES" = "x0" ]; then
         if ! (echo "$singularity_image" | grep "^/cvmfs/") >/dev/null 2>&1; then
             warn "The specified image $singularity_image is not on CVMFS"
@@ -219,9 +222,11 @@ download_or_build_singularity_image () {
             image_name=$(echo "$singularity_image" | sed 's;^[[:alnum:]]*://;;' | sed 's;[:/];__;g')
             singularity_srcs="$singularity_image"
         fi
+        # at this point image_name should be something like "opensciencegrid__osgvo-el8__latest"
 
+        local image_path="$GWMS_THIS_SCRIPT_DIR/images/$image_name"
         # simple lock to prevent multiple slots from attempting dowloading of the same image
-        local lockfile="$GWMS_THIS_SCRIPT_DIR/images/$image_name.lock"
+        local lockfile="$image_path.lock"
         local waitcount=0
         while [[ -e $lockfile && $waitcount -lt 10 ]]; do
             sleep 60s
@@ -229,50 +234,100 @@ download_or_build_singularity_image () {
         done
 
         # already downloaded?
-        if [[ ! -e $GWMS_THIS_SCRIPT_DIR/images/$image_name ]]; then
-            local tmptarget="$GWMS_THIS_SCRIPT_DIR/images/$image_name.$$"
-            local logfile="$GWMS_THIS_SCRIPT_DIR/images/$image_name.log"
+        if [[ -e "$image_path" ]]; then
+            # even if we can use the sif, if we already have the sandbox, use that
+            echo "$image_path"
+            return 0
+        elif [[ -e "$image_path.sif" && $UNPACK_SIF = 0 ]]; then
+            # we already have the sif and we can use it
+            echo "$image_path.sif"
+            return 0
+        else
+            local tmptarget="$image_path.$$"
+            local logfile="$image_path.log"
             local downloaded=0
             touch $lockfile
             rm -f $logfile
+
+            if [[ -e "$image_path.sif" && $UNPACK_SIF = 1 ]]; then
+                # we already have the sif but need to unpack it
+                # (this shouldn't happen very often)
+                if ("$GWMS_SINGULARITY_PATH" build --force --sandbox "$tmptarget" "$image_path.sif" ) &>>"$logfile"; then
+                    mv "$tmptarget" "$image_path"
+                    rm -f "$lockfile" "$image_path.sif"
+                    echo "$image_path"
+                    return 0
+                else
+                    # unpack failed - sif may be damaged
+                    rm -f "$image_path.sif"
+                fi
+            fi
+
+            local tmptarget2
+            local image_path2
+            if [[ $UNPACK_SIF = 0 ]]; then
+                tmptarget2=$tmptarget.sif
+                image_path2=$image_path.sif
+            else
+                tmptarget2=$tmptarget
+                image_path2=$image_path
+            fi
+
             for src in $singularity_srcs; do
                 echo "Trying to download from $src ..." &>>$logfile
+
                 if (echo "$src" | grep "^stash")>/dev/null 2>&1; then
-                    if (stash_download "$tmptarget" "$src") &>>$logfile; then
+                    if (stash_download "$tmptarget2" "$src") &>>$logfile; then
                         downloaded=1
                         break
                     fi
 
                 elif (echo "$src" | grep "^http")>/dev/null 2>&1; then
-                    if (http_download "$tmptarget" "$src") &>>$logfile; then
+                    if (http_download "$tmptarget2" "$src") &>>$logfile; then
                         downloaded=1
                         break
                     fi
 
                 elif (echo "$src" | grep "^docker:" | grep -v "hub.opensciencegrid.org")>/dev/null 2>&1; then
                     # docker is a special case - just pass it through
-                    # hub.opensciencegrid.org will be handled by "singularity build" for now
+                    # hub.opensciencegrid.org will be handled by "singularity build/pull" for now
                     rm -f "$lockfile"
                     echo "$singularity_image"
                     return 0
-                else
-                    if ($GWMS_SINGULARITY_PATH build --force --sandbox "$tmptarget" "$src" ) &>>"$logfile"; then
-                        downloaded=1
-                        break
+
+                elif (echo "$src" | grep "://")>/dev/null 2>&1; then
+                    # some other url
+                    if [[ $UNPACK_SIF = 1 ]]; then
+                        if ($GWMS_SINGULARITY_PATH build --force --sandbox "$tmptarget2" "$src" ) &>>"$logfile"; then
+                            downloaded=1
+                            break
+                        fi
+                    else
+                        # "singularity pull" uses less CPU than "singularity build"
+                        # but $src must be a URL and it can't do --sandbox
+                        if ($GWMS_SINGULARITY_PATH pull --force "$tmptarget2" "$src" ) &>>"$logfile"; then
+                            downloaded=1
+                            break
+                        fi
                     fi
+
+                else
+                    # we shouldn't have a local path at this point
+                    warn "Unexpected non-URL source '$src' for image $singularity_image"
+
                 fi
                 # clean up between attempts
-                rm -f "$tmptarget"
+                rm -rf "$tmptarget2"
             done
             if [[ $downloaded = 1 ]]; then
-                mv "$tmptarget" "$GWMS_THIS_SCRIPT_DIR/images/$image_name"
+                mv "$tmptarget2" "$image_path2"
             else
                 warn "Unable to download or build image ($singularity_image); logs:"
                 cat "$logfile" >&2
-                rm -rf "$tmptarget" "$lockfile"
+                rm -rf "$tmptarget2" "$lockfile"
                 return 1
             fi
-            singularity_image="$GWMS_THIS_SCRIPT_DIR/images/$image_name"
+            singularity_image=$image_path2
             rm -f "$lockfile"
         fi
     fi

--- a/job-wrappers/itb-default_singularity_wrapper.sh
+++ b/job-wrappers/itb-default_singularity_wrapper.sh
@@ -677,6 +677,21 @@ if [[ -z "$GWMS_SINGULARITY_REEXEC" ]]; then
         export ALLOW_NONCVMFS_IMAGES=$(get_prop_bool "$_CONDOR_MACHINE_AD" "ALLOW_NONCVMFS_IMAGES" 0)
         info_dbg "ALLOW_NONCVMFS_IMAGES: $ALLOW_NONCVMFS_IMAGES"
 
+        # Should we use a sif file directly or unpack it first?
+        # Rerun the test from osgvo-default-image and warn if the results don't match what's advertised.
+        advertised_sif_support=$(get_prop_bool "$_CONDOR_MACHINE_AD" "SINGULARITY_CAN_USE_SIF" 0)
+
+        UNPACK_SIF=1
+        detected_sif_support=0
+        if check_singularity_sif_support; then
+            detected_sif_support=1
+            UNPACK_SIF=0
+        fi
+        if [[ $advertised_sif_support != $detected_sif_support ]]; then
+            info_dbg "SIF support: advertised SINGULARITY_CAN_USE_SIF ${advertised_sif_support} != detected ${detected_sif_support}; using detected."
+        fi
+        export UNPACK_SIF
+
         # OSGVO - disabled for now
         # We make sure that every cvmfs repository that users specify in CVMFSReposList is available, otherwise this script exits with 1
         #cvmfs_test_and_open "$CVMFS_REPOS_LIST" exit_wrapper

--- a/node-check/itb-osgvo-default-image
+++ b/node-check/itb-osgvo-default-image
@@ -100,15 +100,26 @@ function check_singularity_sif_support {
     local sylabs_alpine="library://alpine:3"
 
     (
-        singularity build --force alpine.sif "$cvmfs_alpine" ||
-            singularity pull --force alpine.sif "$osghub_alpine" ||
-            singularity pull --force alpine.sif "$sylabs_alpine" ||
-            { echo "*** Could not create alpine.sif"; exit 1; }
-    ) &> alpine.sif.log  || return $?
+        singularity build --force .gwms-alpine.sif "$cvmfs_alpine" ||
+            singularity pull --force .gwms-alpine.sif "$osghub_alpine" ||
+            singularity pull --force .gwms-alpine.sif "$sylabs_alpine" ||
+            echo "All sources failed - could not create .gwms-alpine.sif"
+    ) &> .gwms-alpine.sif.log; ret=$?
+    if [[ $ret != 0 ]]; then
+        info "check_singularity_sif_support() failed to download alpine image"
+        cat .gwms-alpine.sif.log
+        rm -f .gwms-alpine.sif.log .gwms-alpine.sif
+        return $ret
+    fi
+    rm -f .gwms-alpine.sif.log
 
-    output=$(singularity run alpine.sif /bin/true 2>&1) || return $?
+    output=$(singularity run .gwms-alpine.sif /bin/true 2>&1)
+    ret=$?
+    rm -f .gwms-alpine.sif
 
-    if grep -q "temporary sandbox" <<< "$output"; then
+    if [[ $ret != 0 ]]; then
+        return $ret
+    elif grep -q "temporary sandbox" <<< "$output"; then
         return 1
     else
         return 0

--- a/node-check/itb-osgvo-default-image
+++ b/node-check/itb-osgvo-default-image
@@ -173,7 +173,8 @@ function determine_default_container_image {
     # or IMAGES_DIR in the glidein config
     [[ -n $IMAGES_DIR ]] || IMAGES_DIR=$(get_glidein_config_value IMAGES_DIR)
     [[ -n $IMAGES_DIR ]] || IMAGES_DIR=$PWD
-    disk_free=$(df -kP "$IMAGES_DIR" 2>/dev/null | awk '{if (NR==2) print $4}')
+    mkdir -p "$IMAGES_DIR"
+    (( disk_free=$(df -kP "$IMAGES_DIR" 2>/dev/null | awk '{if (NR==2) print $4}') ))
     disk_free_gb=$(($disk_free / 1024 / 1024))
     pull_images=0
     is_itb=$(get_glidein_config_value Is_ITB_Site)

--- a/node-check/itb-osgvo-default-image
+++ b/node-check/itb-osgvo-default-image
@@ -210,8 +210,14 @@ function determine_default_container_image {
         # The subdir will contain the hostname so we can read the link to find out what host it's on
         IMAGES_SUBDIR=$IMAGES_DIR/images-$(hostname)/
         mkdir -p "$IMAGES_SUBDIR"
+        if ! echo x > "$IMAGES_SUBDIR/.test" 2>&1; then
+            info "Not allowing non-CVMFS images, as we couldn't write to the images dir ($IMAGES_SUBDIR)"
+            pull_images=0  # So close!
+        fi
+        rm -f "$IMAGES_SUBDIR/.test"
+    fi
+    if [ $pull_images = 1 ]; then
         ln -snf "$IMAGES_SUBDIR" images
-
         # pull the image into a Singularity SIF file
         IMAGE_NAME=$(echo "$SELECTED_IMAGE" | sed 's;[:/];__;g')
         IMAGE_PATH=$PWD/images/$IMAGE_NAME.sif

--- a/node-check/itb-osgvo-default-image
+++ b/node-check/itb-osgvo-default-image
@@ -157,11 +157,18 @@ function determine_default_container_image {
     fi
 
     # Should we use CVMFS or pull images directly?
+    # TODO: Allow specifying a different images dir
     disk_free=$(df -kP . 2>/dev/null | awk '{if (NR==2) print $4}')
     disk_free_gb=$(($disk_free / 1024 / 1024))
     pull_images=0
     is_itb=$(get_glidein_config_value Is_ITB_Site)
     entry_name=$(get_glidein_config_value GLIDEIN_Entry_Name)
+    singularity_can_use_sif=0
+    if check_singularity_sif_support; then
+        singularity_can_use_sif=1
+        advertise SINGULARITY_CAN_USE_SIF "True" "C"
+    fi
+
     if (echo "x$entry_name" | egrep "OSG_CHTC-canary2") >/dev/null 2>&1; then
         info "Not allowing non-CVMFS images, as the site is on the deny list ($entry_name)"
         pull_images=0

--- a/node-check/itb-osgvo-default-image
+++ b/node-check/itb-osgvo-default-image
@@ -172,6 +172,11 @@ function determine_default_container_image {
     if (echo "x$entry_name" | egrep "OSG_CHTC-canary2") >/dev/null 2>&1; then
         info "Not allowing non-CVMFS images, as the site is on the deny list ($entry_name)"
         pull_images=0
+    elif [ $singularity_can_use_sif = 0 ]; then
+        # Forbid running non-CVMFS images if they have to be unpacked first.
+        # May change later if we find sites where this is "safe."
+        info "Not allowing non-CVMFS images, as Singularity cannot directly run SIF files"
+        pull_images=0
     elif [[ $disk_free_gb -lt 10 ]]; then
         info "Not allowing non-CVMFS images, as the site does not have enough free disk space ($disk_free_gb GBs)"
         pull_images=0

--- a/node-check/itb-osgvo-default-image
+++ b/node-check/itb-osgvo-default-image
@@ -194,7 +194,7 @@ function determine_default_container_image {
         WEEK=$(date +'%V')
         (stash_download $IMAGE_PATH stash:///osgconnect/public/rynge/infrastructure/images/$WEEK/sif/$IMAGE_NAME.sif \
             || http_download $IMAGE_PATH $URL \
-            || singularity build --force $IMAGE_PATH docker://hub.opensciencegrid.org/$SELECTED_IMAGE) >$IMAGE_PATH.log 2>&1
+            || singularity pull --force $IMAGE_PATH docker://hub.opensciencegrid.org/$SELECTED_IMAGE) >$IMAGE_PATH.log 2>&1
         if [ $? = 0 ]; then
             advertise ALLOW_NONCVMFS_IMAGES "True" "C"
             advertise GWMS_SINGULARITY_PULL_IMAGES "True" "C"

--- a/node-check/itb-osgvo-default-image
+++ b/node-check/itb-osgvo-default-image
@@ -86,6 +86,35 @@ function http_download {
     fi
 }
 
+function check_singularity_sif_support {
+    # Return 0 if singularity can directly run a .sif file without having to
+    # unpack it into a temporary sandbox first, nonzero otherwise.
+    #
+    # We know this needs setuid Singularity configured to allow loopback
+    # devices but there may be other conditions so just test it directly.
+
+    # Grab an alpine image from somewhere; ok to download each time since
+    # it's like 3 megs
+    local cvmfs_alpine="/cvmfs/singularity.opensciencegrid.org/library/alpine:latest"
+    local osghub_alpine="docker://hub.opensciencegrid.org/library/alpine:3"
+    local sylabs_alpine="library://alpine:3"
+
+    (
+        singularity build --force alpine.sif "$cvmfs_alpine" ||
+            singularity pull --force alpine.sif "$osghub_alpine" ||
+            singularity pull --force alpine.sif "$sylabs_alpine" ||
+            { echo "*** Could not create alpine.sif"; exit 1; }
+    ) &> alpine.sif.log  || return $?
+
+    output=$(singularity run alpine.sif /bin/true 2>&1) || return $?
+
+    if grep -q "temporary sandbox" <<< "$output"; then
+        return 1
+    else
+        return 0
+    fi
+}
+
 function determine_default_container_image {
     # Selects a default image to use if a job does not specify
     # an image to use. The new style to specify this is with an

--- a/node-check/itb-osgvo-default-image
+++ b/node-check/itb-osgvo-default-image
@@ -168,8 +168,12 @@ function determine_default_container_image {
     fi
 
     # Should we use CVMFS or pull images directly?
-    # TODO: Allow specifying a different images dir
-    disk_free=$(df -kP . 2>/dev/null | awk '{if (NR==2) print $4}')
+
+    # Set image storage location via $IMAGES_DIR in the environment
+    # or IMAGES_DIR in the glidein config
+    [[ -n $IMAGES_DIR ]] || IMAGES_DIR=$(get_glidein_config_value IMAGES_DIR)
+    [[ -n $IMAGES_DIR ]] || IMAGES_DIR=$PWD
+    disk_free=$(df -kP "$IMAGES_DIR" 2>/dev/null | awk '{if (NR==2) print $4}')
     disk_free_gb=$(($disk_free / 1024 / 1024))
     pull_images=0
     is_itb=$(get_glidein_config_value Is_ITB_Site)
@@ -189,7 +193,7 @@ function determine_default_container_image {
         info "Not allowing non-CVMFS images, as Singularity cannot directly run SIF files"
         pull_images=0
     elif [[ $disk_free_gb -lt 10 ]]; then
-        info "Not allowing non-CVMFS images, as the site does not have enough free disk space ($disk_free_gb GBs)"
+        info "Not allowing non-CVMFS images, as the site does not have enough free disk space on the images volume ($disk_free_gb GBs)"
         pull_images=0
     elif [ "x$ALLOW_NONCVMFS_IMAGES" != "x" ]; then
         info "Allowing non-CVMFS images because \$ALLOW_NONCVMFS_IMAGES is set"
@@ -202,7 +206,12 @@ function determine_default_container_image {
         pull_images=1
     fi
     if [ $pull_images = 1 ]; then
-        mkdir -p images
+        # Make an images subdir and symlink to it from the pilot dir
+        # The subdir will contain the hostname so we can read the link to find out what host it's on
+        IMAGES_SUBDIR=$IMAGES_DIR/images-$(hostname)/
+        mkdir -p "$IMAGES_SUBDIR"
+        ln -snf "$IMAGES_SUBDIR" images
+
         # pull the image into a Singularity SIF file
         IMAGE_NAME=$(echo "$SELECTED_IMAGE" | sed 's;[:/];__;g')
         IMAGE_PATH=$PWD/images/$IMAGE_NAME.sif


### PR DESCRIPTION
Check if Singularity can directly execute SIF files; if so, advertise that as SINGULARITY_CAN_USE_SIF, and use SIF files directly instead of unpacking them first. (For now) require SIF files for using non-CVMFS images.

Also allow changing where images are stored outside of the pilot dir; this is done by setting IMAGES_DIR in the environment or glidein config.  Don't use this yet until you have a way of cleaning up IMAGES_DIR.
