### PR TITLE
ITB: Add disk check for SINGULARITY_CAN_USE_REGISTRY

### DIFF
--- a/node-check/itb-osgvo-advertise-base
+++ b/node-check/itb-osgvo-advertise-base
@@ -256,6 +256,34 @@ if [[ "x$GWMS_SINGULARITY_CACHED_IMAGES" != "x" ]]; then
     advertise GWMS_SINGULARITY_CACHED_IMAGES "$GWMS_SINGULARITY_CACHED_IMAGES" "S"
 fi
 
+
+function disk_is_full {
+    local dir_to_check="$1"
+    local required_space_gb="$2"
+    (( disk_free=$(df -kP "$dir_to_check" 2>/dev/null | awk '{if (NR==2) print $4}') ))
+    [[ $(( disk_free / 1024 / 1024 )) -lt $required_space_gb ]]
+}
+
+# check space in SINGULARITY_CACHEDIR and SINGULARITY_TMPDIR
+#
+cachedir_required_space_gb=5
+tmpdir_required_space_gb=5
+
+# ~/.singularity/cache might not have been created yet; if so, check its parents for disk space
+cachedir_to_check=${SINGULARITY_CACHEDIR:-$HOME/.singularity/cache}
+[[ -e $cachedir_to_check ]] || cachedir_to_check=$HOME/.singularity
+[[ -e $cachedir_to_check ]] || cachedir_to_check=$HOME
+tmpdir_to_check=${SINGULARITY_TMPDIR:-${TMPDIR:-/tmp}}
+
+if disk_is_full "$cachedir_to_check" "$cachedir_required_space_gb" || \
+    disk_is_full "$tmpdir_to_check" "$tmpdir_required_space_gb"
+then
+    advertise SINGULARITY_DISK_IS_FULL "True" C
+else
+    advertise SINGULARITY_DISK_IS_FULL "False" C
+fi
+
+
 ##################
 # cvmfs filesystem availability
 GLIDEIN_Entry_Name=$(get_glidein_config_value GLIDEIN_Entry_Name)

--- a/node-check/itb-singularity-extras
+++ b/node-check/itb-singularity-extras
@@ -64,10 +64,9 @@ fi
 if check_singularity_registry_support; then
     # make sure this goes false if we later figure out that
     # singularity is not working correctly
-    advertise SINGULARITY_CAN_USE_REGISTRY "HAS_SINGULARITY" "C"
+    # Pulling from docker:// URLs requires creating a SIF first which is done in the tempdir and is cached in the cachedir
+    advertise SINGULARITY_CAN_USE_REGISTRY "SINGULARITY_CAN_USE_SIF && SINGULARITY_DISK_IS_FULL =!= True" "C"
 else
     advertise SINGULARITY_CAN_USE_REGISTRY "False" "C"
 fi
-
-
 


### PR DESCRIPTION
Pulling from docker:// URLs requires creating a SIF first which is done in $SINGULARITY_TMPDIR and is cached in $SINGULARITY_CACHEDIR; make sure both of these locations have enough free space before advertising SINGULARITY_CAN_USE_REGISTRY.