### PR TITLE
Add OSPool specific ProbeConfig changes to the RPM (SOFTWARE-4841)

### DIFF
--- a/rpm/osg-flock.spec
+++ b/rpm/osg-flock.spec
@@ -43,15 +43,11 @@ overrides=(
 )
 
 for override in "${overrides[@]}"; do
-    key=${override%%=*}
     if grep "$override" $probeconfig 2>&1 > /dev/null; then
         # override already present
         continue
-    elif grep "$key" $probeconfig 2>&1 > /dev/null; then
-        # config value already exists but is not overriden
-        sed -i -e "s/$key.*/$override/" $probeconfig
     else
-        # config value doesn't exist
+        # add override if not present
         sed -i -e "s/\(EnableProbe.*\)/\1\n    $override/" $probeconfig
     fi
 done

--- a/rpm/osg-flock.spec
+++ b/rpm/osg-flock.spec
@@ -36,7 +36,6 @@ install -d $RPM_BUILD_ROOT/%{_sysconfdir}/gratia/condor/
 # Set OSPool specific Gratia probe config
 probeconfig=/etc/gratia/condor-ap/ProbeConfig
 overrides=(
-    'SuppressGridLocalRecords="1"'
     'MapUnknownToGroup="1"'
     'MapGroupToRole="1"'
     'VOOverride="OSG"'

--- a/rpm/osg-flock.spec
+++ b/rpm/osg-flock.spec
@@ -1,6 +1,6 @@
 Name:      osg-flock
 Version:   1.6
-Release:   2%{?dist}
+Release:   3%{?dist}
 Summary:   OSG configurations for a flocking host
 
 License:   Apache 2.0
@@ -8,7 +8,7 @@ URL:       https://opensciencegrid.org/docs/submit/osg-flock
 
 BuildArch: noarch
 
-Requires: gratia-probe-condor-ap
+Requires(post): gratia-probe-condor-ap
 Requires: condor
 
 Source0: %{name}-%{version}%{?gitrev:-%{gitrev}}.tar.gz
@@ -32,6 +32,30 @@ install -m 644 rpm/80-osg-flocking.conf $RPM_BUILD_ROOT/%{_sysconfdir}/condor/co
 # Install gratia configuration
 install -d $RPM_BUILD_ROOT/%{_sysconfdir}/gratia/condor/
 
+%post
+# Set OSPool specific Gratia probe config
+probeconfig=/etc/gratia/condor-ap/ProbeConfig
+overrides=(
+    'SuppressGridLocalRecords="1"'
+    'MapUnknownToGroup="1"'
+    'MapGroupToRole="1"'
+    'VOOverride="OSG"'
+)
+
+for override in "${overrides[@]}"; do
+    key=${override%%=*}
+    if grep "$override" $probeconfig 2>&1 > /dev/null; then
+        # override already present
+        continue
+    elif grep "$key" $probeconfig 2>&1 > /dev/null; then
+        # config value already exists but is not overriden
+        sed -i -e "s/$key.*/$override/" $probeconfig
+    else
+        # config value doesn't exist
+        sed -i -e "s/\(EnableProbe.*\)/\1\n    $override/" $probeconfig
+    fi
+done
+
 %clean
 rm -rf $RPM_BUILD_ROOT
 
@@ -43,6 +67,10 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Thu Nov 4 2021 Brian Lin <blin@cs.wisc.edu> - 1.6-3
+- Append OSPool specific ProbeConfig changes in post-installation
+  (SOFTWARE-4846)
+
 * Wed Oct 27 2021 Brian Lin <blin@cs.wisc.edu> 1.6-2
 - Remove reference to old ProbeConfig
 


### PR DESCRIPTION
Tested with https://github.com/opensciencegrid/gratia-probe/pull/128 and verified that the appropriate config is laid down

One problem with the case where we replace the value of an existing key: this effectively means that users can't set any of the attributes that we're setting in `%post`. We could get rid of it but then we'd have to figure out what to do with `SuppressGridLocalRecords`, which is set to `0` in the default ProbeConfig but we need it to be `1` for OSPool APs. I'm not sure if this is something that we should just set generally for all APs.