### PR TITLE
Revert "Turn off alloc-Stampede2-CPU-TG-CHE200122 for now"

### DIFF
--- a/flock.opensciencegrid.org/frontend-template.xml
+++ b/flock.opensciencegrid.org/frontend-template.xml
@@ -1049,8 +1049,7 @@
             </file>
          </files>
       </group>
-      <group name="alloc-Stampede2-CPU-TG-CHE200122" enabled="False">
-          <!-- off until we get more pilots on Stampede2 to give room for UTAustin_Zimmerman -->
+      <group name="alloc-Stampede2-CPU-TG-CHE200122" enabled="True">
          <config ignore_down_entries="">
             <glideins_removal margin="0" requests_tracking="False" type="NO" wait="0"/>
             <idle_glideins_lifetime max="864000"/>


### PR DESCRIPTION
We now have enough pilots on Stampede2 that we can reenable the other allocation
