### PR TITLE
Add job transforms based on SingularityImage

### DIFF
--- a/ospool.osg-htc.org/development/htcondor-config.d/95_singularity_job_transforms.config
+++ b/ospool.osg-htc.org/development/htcondor-config.d/95_singularity_job_transforms.config
@@ -12,6 +12,9 @@ JOB_TRANSFORM_singularity @=jt
     # A later transform will set this
     DELETE DockerRegistry
 
+    # HTCondor's Singularity detection
+    SET Requirements $(MY.Requirements) && TARGET.HasSingularity
+
     EVALMACRO IsDockerURL = substr(SingularityImage, 0, 9) == "docker://"
     EVALMACRO IsCVMFSPath = substr(SingularityImage, 0, 7) is "/cvmfs/"
     EVALMACRO IsSIF = size(SingularityImage) > 4 && substr(SingularityImage, -4) == ".sif")
@@ -36,9 +39,6 @@ JOB_TRANSFORM_singularity @=jt
     # OSG VO's HAS_SINGULARITY also implies that images synced to CVMFS will run
     if $(IsCVMFSPath)
         SET Requirements $(MY.Requirements) && TARGET.HAS_SINGULARITY
-    else
-        # HTCondor's built in Singularity detection
-        SET Requirements $(MY.Requirements) && TARGET.HasSingularity
     endif
 @jt
 

--- a/ospool.osg-htc.org/development/htcondor-config.d/95_singularity_job_transforms.config
+++ b/ospool.osg-htc.org/development/htcondor-config.d/95_singularity_job_transforms.config
@@ -1,0 +1,88 @@
+JOB_TRANSFORM_NAMES = \
+    singularity \
+    DockerURL_expand_1_part \
+    DockerURL_expand_2_part_no_repo \
+    DockerURL_expand_2_part_no_registry \
+    set_DockerRegistry
+
+
+JOB_TRANSFORM_singularity @=jt
+    REQUIREMENTS isString(SingularityImage) && SingularityImage != ""
+
+    # A later transform will set this
+    DELETE DockerRegistry
+
+    EVALMACRO IsDockerURL = substr(SingularityImage, 0, 9) == "docker://"
+    EVALMACRO IsCVMFSPath = substr(SingularityImage, 0, 7) is "/cvmfs/"
+    EVALMACRO IsSIF = size(SingularityImage) > 4 && substr(SingularityImage, -4) == ".sif")
+
+    EVALMACRO AddToTransferInput = ! $(IsDockerURL) && ! $(IsCVMFSPath) && $(MY.Should_Transfer_Container:1)
+
+    if $(AddToTransferInput)
+        SET TransferInput "$(MY.TransferInput),$(MY.SingularityImage)"
+        COPY SingularityImage orig_SingularityImage
+        # The basename will be the name of the file in the sandbox directory
+        SET SingularityImage "$BASENAME(MY.SingularityImage)"
+    endif
+
+    if $(IsSIF)
+        SET Requirements $(MY.Requirements) && TARGET.SINGULARITY_CAN_USE_SIF
+    endif
+
+    if $(IsDockerURL)
+        SET Requirements $(MY.Requirements) && TARGET.SINGULARITY_CAN_USE_REGISTRY
+    endif
+
+    # OSG VO's HAS_SINGULARITY also implies that images synced to CVMFS will run
+    if $(IsCVMFSPath)
+        SET Requirements $(MY.Requirements) && TARGET.HAS_SINGULARITY
+    else
+        # HTCondor's built in Singularity detection
+        SET Requirements $(MY.Requirements) && TARGET.HasSingularity
+    endif
+@jt
+
+
+#
+# Expand (fully qualify) docker:// URLs -- this means "docker://REGISTRY/REPOSITORY/NAME"
+#
+
+# 1-part docker:// URL: just the name.
+JOB_TRANSFORM_DockerURL_expand_1_part @=jt
+    REQUIREMENTS regexp("^docker://[^/]+$", SingularityImage)
+
+    # Add the "docker.io" registry and the "library" repository to fully qualify the image URL
+    COPY SingularityImage orig_SingularityImage
+    EVALSET SingularityImage replace("^docker://(.+)", SingularityImage, "docker://docker.io/library/\\1")
+@jt
+
+# 2-part docker:// URL (type a): includes registry (maybe with :PORT) and name, but not repository
+# (you can tell the first component is a registry because it has a "." or a :PORT)
+JOB_TRANSFORM_DockerURL_expand_2_part_no_repo @=jt
+    REQUIREMENTS regexp("^docker://[^/.]+[.:][^/]+/[^/]+$", SingularityImage)
+
+    # Add the "library" repository to fully qualify the image URL
+    COPY SingularityImage orig_SingularityImage
+    EVALSET SingularityImage replace("^docker://([^/]+)/(.*)", SingularityImage, "docker://\\1/library/\\2")
+@jt
+
+# 2-part docker:// URL (type b): includes repository and name but not registry
+# (you can tell the first component isn't a registry because it has no "." or port)
+JOB_TRANSFORM_DockerURL_expand_2_part_no_registry @=jt
+    REQUIREMENTS regexp("^docker://[^/.:]+/[^/]+$", SingularityImage)
+
+    # Add the "docker.io" registry to fully qualify the image URL
+    COPY SingularityImage orig_SingularityImage
+    EVALSET SingularityImage replace("^docker://(.+)", SingularityImage, "docker://docker.io/\\1")
+@jt
+
+#
+# Extract the registry from a fully qualified docker:// URL.
+#
+
+JOB_TRANSFORM_set_DockerRegistry @=jt
+    REQUIREMENTS regexp("^docker://[^/]+/[^/]+/[^/]+$", SingularityImage)
+
+    # Take just the registry hostname; chop off the port
+    EVALSET DockerRegistry replace("^docker://([^/:]+)(:[0-9]+)?/.*", SingularityImage, "\\1")
+@jt

--- a/ospool.osg-htc.org/development/htcondor-config.d/95_singularity_job_transforms.config
+++ b/ospool.osg-htc.org/development/htcondor-config.d/95_singularity_job_transforms.config
@@ -1,4 +1,5 @@
 JOB_TRANSFORM_NAMES = \
+    $(JOB_TRANSFORM_NAMES) \
     singularity \
     DockerURL_expand_1_part \
     DockerURL_expand_2_part_no_repo \


### PR DESCRIPTION
- if the image is from CVMFS, add the `HAS_SINGULARITY` requirement; otherwise add the `HasSingularity` requirement
- if the image is not from CVMFS and not a `docker://` URL, add it to `TransferInput`, unless you set `Should_Transfer_Container=false`
- if the image is a `docker://` URL, fully qualify the URL to `docker://REGISTRY/REPOSITORY/NAME` and put the registry hostname into `DockerRegistry`

Docker URL expansion rules are:
- If the REGISTRY is omitted, use "docker.io"
- If the REPOSITORY is omitted, use "library"
- For a 2-component URL (either REGISTRY or REPOSITORY are omitted, not both),
  assume the first component is a registry if it looks like a host (has a ".") or has a port (e.g. ":443").
  Otherwise assume the first component is a repository.
