### PR TITLE
Add /usr/sbin to PATH so singularity can find mksquashfs

### DIFF
--- a/job-wrappers/itb-default_singularity_wrapper.sh
+++ b/job-wrappers/itb-default_singularity_wrapper.sh
@@ -656,6 +656,9 @@ if [[ -z "$GWMS_SINGULARITY_REEXEC" ]]; then
         #
         info_dbg "Decided to use singularity ($HAS_SINGULARITY, $GWMS_SINGULARITY_PATH). Proceeding w/ tests and setup."
 
+        # for mksquashfs
+        PATH=$PATH:/usr/sbin
+
         # Should we use CVMFS or pull images directly?
         export ALLOW_NONCVMFS_IMAGES=$(get_prop_bool "$_CONDOR_MACHINE_AD" "ALLOW_NONCVMFS_IMAGES" 0)
         info_dbg "ALLOW_NONCVMFS_IMAGES: $ALLOW_NONCVMFS_IMAGES"

--- a/node-check/itb-osgvo-advertise-base
+++ b/node-check/itb-osgvo-advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=596
+OSG_GLIDEIN_VERSION=597
 #######################################################################
 
 


### PR DESCRIPTION
singularity needs to have mksquashfs in PATH to build SIF files. mksquashfs is in /usr/sbin. We didn't catch this problem in the node check script because PATH in that script contains /usr/sbin.