### PR TITLE
Fix statistics reporting at non-OSPool frontends.

### DIFF
--- a/node-check/osgvo-node-advertise
+++ b/node-check/osgvo-node-advertise
@@ -153,6 +153,14 @@ function determine_default_container_image {
     echo $SELECTED_IMAGE >osgvo.default-singularity-image
 }
 
+#############################################################################
+# At least glideinWMS 3.7.5 depends on the existence of a file named
+# log/StarterLog.  However, starting in 8.9.13, this log file no longer is
+# created by HTCondor.  To fix the statistics reporting, we simply create it
+# here.
+mkdir -p log execute
+touch log/StarterLog
+
 ###########################################################
 # Ensure only one copy of this script is running at the 
 # same time. For example, if a mount or something hangs


### PR DESCRIPTION
This was already fixed for the OSPool frontend - which uses a separate file for advertising the basics.

We really should discuss this file overall: I suspect Mats will be surprised to hear all the other frontends are depending on it!