### PR TITLE
Disable stashcp at UTC-Epyc (OSPOOL-11)

### DIFF
--- a/node-check/osgvo-additional-htcondor-config
+++ b/node-check/osgvo-additional-htcondor-config
@@ -65,7 +65,8 @@ STASHCP=$PWD/client/stashcp
 chmod 755 $STASHCP
 
 # also run a simple test
-if ($STASHCP /osgconnect/public/dweitzel/stashcp/test.file stashcp-test.file) &>/dev/null; then
+if ($STASHCP /osgconnect/public/dweitzel/stashcp/test.file stashcp-test.file) &>/dev/null &&
+   [[ $OSG_SITE_NAME != "UTC-Epyc" ]]; then
 
     cat >stashcp_plugin <<EOF
 #!/bin/sh


### PR DESCRIPTION
We suspect that the site does not have enough bandwidth to support
stash transfer. This is a hacky, quick fix: ideally we'd set an env
var at the CE level that we can check for to disable stash.