### PR TITLE
Get $OSG_SITE_NAME from GLIDEIN_Site if necessary

### DIFF
--- a/node-check/osgvo-additional-htcondor-config
+++ b/node-check/osgvo-additional-htcondor-config
@@ -64,6 +64,11 @@ add_condor_vars_line CHIRP_DELAYED_UPDATE_PREFIX "C" "-" "+" "N" "N" "-"
 STASHCP=$PWD/client/stashcp
 chmod 755 $STASHCP
 
+glidein_site=`grep -i "^GLIDEIN_Site " $glidein_config | awk '{print $2}'`
+if [[ -z $OSG_SITE_NAME ]]; then
+    OSG_SITE_NAME=$glidein_site
+fi
+
 # also run a simple test
 if ($STASHCP /osgconnect/public/dweitzel/stashcp/test.file stashcp-test.file) &>/dev/null &&
    [[ $OSG_SITE_NAME != "UTC-Epyc" ]]; then

--- a/node-check/osgvo-advertise-base
+++ b/node-check/osgvo-advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=599
+OSG_GLIDEIN_VERSION=600
 #######################################################################
 
 


### PR DESCRIPTION
We do this as part of a quick & dirty check to avoid installing the stash plugin on UTC-Epyc.