### PR TITLE
Partial revert of "- Moved to the new ospool.osg-htc.org central...

### DIFF
--- a/rpm/80-osg-flocking.conf
+++ b/rpm/80-osg-flocking.conf
@@ -18,11 +18,6 @@ SCHEDD_DEBUG = D_AUDIT
 MAX_SCHEDD_AUDIT_LOG = 1d
 MAX_NUM_SCHEDD_AUDIT_LOG = 90
 
-# Clients should be able to query without encryption + authentication
-SEC_CLIENT_AUTHENTICATION = OPTIONAL
-SEC_CLIENT_ENCRYPTION = OPTIONAL
-SEC_CLIENT_INTEGRITY = OPTIONAL
-
 # When communicating with the OSPool, encryption + authentication is required.
 # Note, in 9.0.0 and later, encryption implies integrity.
 SCHEDD.SEC_CLIENT_AUTHENTICATION = REQUIRED

--- a/rpm/osg-flock.spec
+++ b/rpm/osg-flock.spec
@@ -67,8 +67,6 @@ rm -rf $RPM_BUILD_ROOT
   availability setup
 - Removed pre-9.0 HTCondor config - this is no longer
   supported by the OSPool (IDTOKENS only)
-- Added SEC_CLIENT_*=OPTIONAL config to provide a nicer
-  experience when querying the collectors
 - Change the VO override to the lowercase "osg" (SOFTWARE-4905)
 
 * Thu Nov 4 2021 Brian Lin <blin@cs.wisc.edu> - 1.6-3


### PR DESCRIPTION
managers in high"; this partially reverts commit
df72ff9b8b5e65e88b4ff63a8d40d0debbcff92d.

SSL authentication is fairly open on the client side if the server
side presents a valid host certificate. Remote client queries
currently fail against the HA collectors because their certs do not
contain their osg-htc.org FQDNs in their SANs.

We're working on getting the `osg-htc.org` config ready in Tiger this week