### PR TITLE
Enable syslog for production pilots

### DIFF
--- a/ospool.osg-htc.org/development/frontend-template.xml
+++ b/ospool.osg-htc.org/development/frontend-template.xml
@@ -68,6 +68,7 @@
       <attr name="OSG_DEFAULT_CVMFS_DATA" glidein_publish="False" job_publish="False" parameter="True" type="string" value="/cvmfs/stash.osgstorage.org"/>
       <attr name="STARTD_JOB_ATTRS" glidein_publish="False" job_publish="False" parameter="True" type="string" value="ProjectName"/>
       <attr name="USE_MATCH_AUTH" glidein_publish="False" job_publish="False" parameter="True" type="string" value="True"/>
+      <attr name="SYSLOG_HOST" parameter="False" type="expr" value="syslog.osgdev.chtc.io"/>
    </attrs>
    <groups>
       <group name="itb" enabled="True">
@@ -189,7 +190,6 @@
             <attr name="SLOTS_LAYOUT" glidein_publish="True" job_publish="True" parameter="False" type="string" value="partitionable"/>
             <attr name="OSG_DEFAULT_CONTAINER_DISTRIBUTION" glidein_publish="False" job_publish="False" parameter="True" type="string" value="25%__opensciencegrid/osgvo-el7:latest 25%__opensciencegrid/osgvo-ubuntu-18.04:latest 25%__opensciencegrid/osgvo-el8:latest 25%__opensciencegrid/osgvo-ubuntu-20.04:latest"/>
             <attr name="OSG_DEFAULT_CONTAINER_DISTRIBUTION_GPU" glidein_publish="False" job_publish="False" parameter="True" type="string" value="100%__opensciencegrid/osgvo-el7-cuda10:latest"/>
-            <attr name="SYSLOG_HOST" parameter="False" type="expr" value="syslog.osgdev.chtc.io"/>
          </attrs>
          <files>
             <file absfname="/opt/osg-flock/node-check/itb-ospool-lib" after_entry="False" const="True" executable="True" period="0" prefix="NOPREFIX" untar="False" wrapper="False">

--- a/ospool.osg-htc.org/production/frontend-template.xml
+++ b/ospool.osg-htc.org/production/frontend-template.xml
@@ -102,6 +102,7 @@
       <attr name="OSG_DEFAULT_CVMFS_DATA" glidein_publish="False" job_publish="False" parameter="True" type="string" value="/cvmfs/stash.osgstorage.org"/>
       <attr name="STARTD_JOB_ATTRS" glidein_publish="False" job_publish="False" parameter="True" type="string" value="ProjectName"/>
       <attr name="USE_MATCH_AUTH" glidein_publish="False" job_publish="False" parameter="True" type="string" value="True"/>
+      <attr name="SYSLOG_HOST" parameter="False" type="expr" value="syslog.osg.chtc.io"/>
    </attrs>
    <groups>
 
@@ -910,5 +911,9 @@
       <file absfname="/opt/osg-flock/node-check/eic-data-attributes" after_entry="True" after_group="False" const="True" executable="True" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="False">
          <untar_options cond_attr="TRUE"/>
       </file>
+      <file absfname="/opt/rsyslog-pilot/rsyslog.tar.gz" prefix="NOPREFIX" untar="True">
+          <untar_options cond_attr="TRUE" dir="../rsyslog"/>
+      </file>
+      <file absfname="/opt/rsyslog-pilot/rsyslog_startup.sh" executable="True" prefix="NOPREFIX"/>
    </files>
 </frontend>


### PR DESCRIPTION
Adds the rsyslog tarball to the production frontend and enables by default for all production pilots.