### PR TITLE
Use $CVMFS_BASE for systems where we have to use mountrepo from cvmfsexec

### DIFF
--- a/node-check/itb-osgvo-advertise-userenv
+++ b/node-check/itb-osgvo-advertise-userenv
@@ -133,6 +133,11 @@ if [ "x$PATH" = "x" ]; then
 fi
 info "PATH is set to $PATH"
 
+# CVMFS_BASE defaults to /cvmfs but can be overridden in case of for example cvmfsexec
+if [ "x$CVMFS_BASE" = "x" ]; then
+    CVMFS_BASE="/cvmfs"
+fi
+
 if [ "x$glidein_config" = "x" ]; then
     glidein_config="NONE"
     info "No arguments provided - assuming HTCondor startd cron mode"
@@ -299,11 +304,11 @@ if [ -e $TEST_FILE_1H.modules ]; then
     RESULT=`cat $TEST_FILE_1H.modules`
 else
    # extra check to make sure we can read a file
-   if cat /cvmfs/oasis.opensciencegrid.org/osg/README.txt >/dev/null 2>&1; then
-      if cat /cvmfs/connect.opensciencegrid.org/modules/spack/bin/spack >/dev/null 2>&1; then
-          if (. /cvmfs/oasis.opensciencegrid.org/osg/sw/module-init.sh && module avail) >/dev/null 2>&1; then
+   if cat "$CVMFS_BASE"/oasis.opensciencegrid.org/osg/README.txt >/dev/null 2>&1; then
+      if cat "$CVMFS_BASE"/connect.opensciencegrid.org/modules/spack/bin/spack >/dev/null 2>&1; then
+          if (. "$CVMFS_BASE"/oasis.opensciencegrid.org/osg/sw/module-init.sh && module avail) >/dev/null 2>&1; then
               # also make sure module avail is not throwing a stack trace
-              if ! (. /cvmfs/oasis.opensciencegrid.org/osg/sw/module-init.sh && module avail 2>&1 | grep traceback) >/dev/null 2>&1; then
+              if ! (. "$CVMFS_BASE"/oasis.opensciencegrid.org/osg/sw/module-init.sh && module avail 2>&1 | grep traceback) >/dev/null 2>&1; then
                   RESULT="True"
                   echo "True" > $TEST_FILE_1H.modules
               else
@@ -348,7 +353,7 @@ rm -f test.txt
 STASHCP_VERIFIED="False"
 if [ -e $TEST_FILE_1H.stashcp ]; then
     STASHCP_VERIFIED=`cat $TEST_FILE_1H.stashcp`
-elif (. /cvmfs/oasis.opensciencegrid.org/osg/sw/module-init.sh && module load stashcache && $TIMEOUT_CMD stashcp --methods=http,xrootd /osgconnect/public/rynge/glidein-checks/testfile .) >/dev/null 2>&1; then
+elif (. "$CVMFS_BASE"/oasis.opensciencegrid.org/osg/sw/module-init.sh && module load stashcache && $TIMEOUT_CMD stashcp --methods=http,xrootd /osgconnect/public/rynge/glidein-checks/testfile .) >/dev/null 2>&1; then
     STASHCP_VERIFIED="True"
     echo "True" > $TEST_FILE_1H.stashcp
 else

--- a/node-check/osgvo-advertise-userenv
+++ b/node-check/osgvo-advertise-userenv
@@ -133,6 +133,11 @@ if [ "x$PATH" = "x" ]; then
 fi
 info "PATH is set to $PATH"
 
+# CVMFS_BASE defaults to /cvmfs but can be overridden in case of for example cvmfsexec
+if [ "x$CVMFS_BASE" = "x" ]; then
+    CVMFS_BASE="/cvmfs"
+fi
+
 if [ "x$glidein_config" = "x" ]; then
     glidein_config="NONE"
     info "No arguments provided - assuming HTCondor startd cron mode"
@@ -299,11 +304,11 @@ if [ -e $TEST_FILE_1H.modules ]; then
     RESULT=`cat $TEST_FILE_1H.modules`
 else
    # extra check to make sure we can read a file
-   if cat /cvmfs/oasis.opensciencegrid.org/osg/README.txt >/dev/null 2>&1; then
-      if cat /cvmfs/connect.opensciencegrid.org/modules/spack/bin/spack >/dev/null 2>&1; then
-          if (. /cvmfs/oasis.opensciencegrid.org/osg/sw/module-init.sh && module avail) >/dev/null 2>&1; then
+   if cat "$CVMFS_BASE"/oasis.opensciencegrid.org/osg/README.txt >/dev/null 2>&1; then
+      if cat "$CVMFS_BASE"/connect.opensciencegrid.org/modules/spack/bin/spack >/dev/null 2>&1; then
+          if (. "$CVMFS_BASE"/oasis.opensciencegrid.org/osg/sw/module-init.sh && module avail) >/dev/null 2>&1; then
               # also make sure module avail is not throwing a stack trace
-              if ! (. /cvmfs/oasis.opensciencegrid.org/osg/sw/module-init.sh && module avail 2>&1 | grep traceback) >/dev/null 2>&1; then
+              if ! (. "$CVMFS_BASE"/oasis.opensciencegrid.org/osg/sw/module-init.sh && module avail 2>&1 | grep traceback) >/dev/null 2>&1; then
                   RESULT="True"
                   echo "True" > $TEST_FILE_1H.modules
               else
@@ -348,7 +353,7 @@ rm -f test.txt
 STASHCP_VERIFIED="False"
 if [ -e $TEST_FILE_1H.stashcp ]; then
     STASHCP_VERIFIED=`cat $TEST_FILE_1H.stashcp`
-elif (. /cvmfs/oasis.opensciencegrid.org/osg/sw/module-init.sh && module load stashcache && $TIMEOUT_CMD stashcp --methods=http,xrootd /osgconnect/public/rynge/glidein-checks/testfile .) >/dev/null 2>&1; then
+elif (. "$CVMFS_BASE"/oasis.opensciencegrid.org/osg/sw/module-init.sh && module load stashcache && $TIMEOUT_CMD stashcp --methods=http,xrootd /osgconnect/public/rynge/glidein-checks/testfile .) >/dev/null 2>&1; then
     STASHCP_VERIFIED="True"
     echo "True" > $TEST_FILE_1H.stashcp
 else


### PR DESCRIPTION
This is the only remaining difference between the wip-* set of scripts used on Stampede and the production scripts.