### PR TITLE
Add gluex to CVMFS list

### DIFF
--- a/node-check/osgvo-advertise-base
+++ b/node-check/osgvo-advertise-base
@@ -304,6 +304,7 @@ for FS in \
    connect.opensciencegrid.org \
    desdm.osgstorage.org \
    eic.opensciencegrid.org \
+   gluex.osgstorage.org \
    gwosc.osgstorage.org \
    icecube.opensciencegrid.org \
    larsoft-ib.opensciencegrid.org \


### PR DESCRIPTION
To allow Gluex users to put `HAS_CVMFS_gluex_osgstorage_org == true` in their jobs.