### PR TITLE
Check stashcp presence and version in the userenv script (ITB)

### DIFF
--- a/node-check/itb-osgvo-advertise-base
+++ b/node-check/itb-osgvo-advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=628
+OSG_GLIDEIN_VERSION=629
 #######################################################################
 
 

--- a/node-check/itb-osgvo-advertise-userenv
+++ b/node-check/itb-osgvo-advertise-userenv
@@ -304,6 +304,17 @@ if (cat /stash/user/test.osgconnect.1M) >/dev/null 2>&1; then
     fi
 fi
 
+# advertise the version of stashcp found in $PATH
+if STASHCP_VERSION=$(stashcp --version)
+then
+    STASHCP_VERSION=$(echo "$STASHCP_VERSION" | head -n1 | grep -o "[0-9][0-9.]\+")
+    advertise STASHCP_VERSION "$STASHCP_VERSION" "S"
+else
+    # version check failed; we don't actually have a working stashcp
+    advertise STASHCP_VERSION UNDEFINED "C"
+    advertise STASHCP_VERIFIED "False" "C"
+fi
+
 ##################
 # cms software
 


### PR DESCRIPTION
I've landed on plenty of nodes that advertised 6.7.5 as the STASHCP_VERSION but what was in the job was older.

This pattern matches the version string for both the Python and the Go versions of stashcp.