### PR TITLE
ITB: Patch over add_config_line() with a safer version that is less likely to stomp over the glidein_config when run concurrently

### DIFF
--- a/node-check/itb-osgvo-additional-htcondor-config
+++ b/node-check/itb-osgvo-additional-htcondor-config
@@ -8,6 +8,41 @@ glidein_config="$1"
 add_config_line_source=`grep '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}'`
 source $add_config_line_source
 
+# Patch over add_config_line() with a safer version
+add_config_line() {
+    # Ignore the call if the exact config line is already in there
+    if ! grep -q "^${*}$" "${glidein_config}"; then
+        # Use temporary files to make sure multiple add_config_line() calls don't clobber
+        # the glidein_config.
+        local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
+        local tmp_config1="${glidein_config}.$r.1"
+        local tmp_config2="${glidein_config}.$r.2"
+
+        # Copy the glidein config so it doesn't get modified while we grep out the old value
+        if ! cp -p "${glidein_config}" "${tmp_config1}"; then
+            warn "Error writing ${tmp_config1}"
+            rm -f "${tmp_config1}"
+            exit 1
+        fi
+        grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
+        rm -f "${tmp_config1}"
+        if [ ! -f "${tmp_config2}" ]; then
+            warn "Error creating ${tmp_config2}"
+            exit 1
+        fi
+        # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
+        echo "$@" >> "${tmp_config2}"
+
+        # Replace glidein config atomically
+        if ! mv -f "${tmp_config2}" "${glidein_config}"; then
+            warn "Error updating ${glidein_config} from ${tmp_config2}"
+            rm -f "${tmp_config2}"
+            exit 1
+        fi
+    fi
+}
+# End add_config_line() patch
+
 condor_vars_file=`grep -i "^CONDOR_VARS_FILE " $glidein_config | awk '{print $2}'`
 
 ###########################################################

--- a/node-check/itb-osgvo-advertise-base
+++ b/node-check/itb-osgvo-advertise-base
@@ -201,6 +201,41 @@ if [ "$glidein_config" != "NONE" ]; then
 
     info "Sourcing $add_config_line_source"
     source $add_config_line_source
+
+    # XXX Patch over add_config_line() with a safer version
+    add_config_line() {
+        # Ignore the call if the exact config line is already in there
+        if ! grep -q "^${*}$" "${glidein_config}"; then
+            # Use temporary files to make sure multiple add_config_line() calls don't clobber
+            # the glidein_config.
+            local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
+            local tmp_config1="${glidein_config}.$r.1"
+            local tmp_config2="${glidein_config}.$r.2"
+
+            # Copy the glidein config so it doesn't get modified while we grep out the old value
+            if ! cp -p "${glidein_config}" "${tmp_config1}"; then
+                warn "Error writing ${tmp_config1}"
+                rm -f "${tmp_config1}"
+                exit 1
+            fi
+            grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
+            rm -f "${tmp_config1}"
+            if [ ! -f "${tmp_config2}" ]; then
+                warn "Error creating ${tmp_config2}"
+                exit 1
+            fi
+            # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
+            echo "$@" >> "${tmp_config2}"
+
+            # Replace glidein config atomically
+            if ! mv -f "${tmp_config2}" "${glidein_config}"; then
+                warn "Error updating ${glidein_config} from ${tmp_config2}"
+                rm -f "${tmp_config2}"
+                exit 1
+            fi
+        fi
+    }
+    # XXX End add_config_line() patch
 fi
 
 # timeout, if available, is used across many tests

--- a/node-check/itb-osgvo-advertise-userenv
+++ b/node-check/itb-osgvo-advertise-userenv
@@ -153,6 +153,41 @@ if [ "$glidein_config" != "NONE" ]; then
 
     info "Sourcing $add_config_line_source"
     source $add_config_line_source
+
+    # XXX Patch over add_config_line() with a safer version
+    add_config_line() {
+        # Ignore the call if the exact config line is already in there
+        if ! grep -q "^${*}$" "${glidein_config}"; then
+            # Use temporary files to make sure multiple add_config_line() calls don't clobber
+            # the glidein_config.
+            local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
+            local tmp_config1="${glidein_config}.$r.1"
+            local tmp_config2="${glidein_config}.$r.2"
+
+            # Copy the glidein config so it doesn't get modified while we grep out the old value
+            if ! cp -p "${glidein_config}" "${tmp_config1}"; then
+                warn "Error writing ${tmp_config1}"
+                rm -f "${tmp_config1}"
+                exit 1
+            fi
+            grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
+            rm -f "${tmp_config1}"
+            if [ ! -f "${tmp_config2}" ]; then
+                warn "Error creating ${tmp_config2}"
+                exit 1
+            fi
+            # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
+            echo "$@" >> "${tmp_config2}"
+
+            # Replace glidein config atomically
+            if ! mv -f "${tmp_config2}" "${glidein_config}"; then
+                warn "Error updating ${glidein_config} from ${tmp_config2}"
+                rm -f "${tmp_config2}"
+                exit 1
+            fi
+        fi
+    }
+    # XXX End add_config_line() patch
 fi
 
 # timeout - need this early as we use it in some commands later

--- a/node-check/itb-osgvo-default-image
+++ b/node-check/itb-osgvo-default-image
@@ -159,6 +159,41 @@ if [ "$glidein_config" != "NONE" ]; then
     add_config_line_source=$PWD/add_config_line.source
 
     source $add_config_line_source
+
+    # XXX Patch over add_config_line() with a safer version
+    add_config_line() {
+        # Ignore the call if the exact config line is already in there
+        if ! grep -q "^${*}$" "${glidein_config}"; then
+            # Use temporary files to make sure multiple add_config_line() calls don't clobber
+            # the glidein_config.
+            local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
+            local tmp_config1="${glidein_config}.$r.1"
+            local tmp_config2="${glidein_config}.$r.2"
+
+            # Copy the glidein config so it doesn't get modified while we grep out the old value
+            if ! cp -p "${glidein_config}" "${tmp_config1}"; then
+                warn "Error writing ${tmp_config1}"
+                rm -f "${tmp_config1}"
+                exit 1
+            fi
+            grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
+            rm -f "${tmp_config1}"
+            if [ ! -f "${tmp_config2}" ]; then
+                warn "Error creating ${tmp_config2}"
+                exit 1
+            fi
+            # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
+            echo "$@" >> "${tmp_config2}"
+
+            # Replace glidein config atomically
+            if ! mv -f "${tmp_config2}" "${glidein_config}"; then
+                warn "Error updating ${glidein_config} from ${tmp_config2}"
+                rm -f "${tmp_config2}"
+                exit 1
+            fi
+        fi
+    }
+    # XXX End add_config_line() patch
 fi
 
 # source our helpers

--- a/node-check/itb-singularity-extras
+++ b/node-check/itb-singularity-extras
@@ -41,6 +41,41 @@ if [ "$glidein_config" != "NONE" ]; then
 
     info "Sourcing $add_config_line_source"
     source $add_config_line_source
+
+    # XXX Patch over add_config_line() with a safer version
+    add_config_line() {
+        # Ignore the call if the exact config line is already in there
+        if ! grep -q "^${*}$" "${glidein_config}"; then
+            # Use temporary files to make sure multiple add_config_line() calls don't clobber
+            # the glidein_config.
+            local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
+            local tmp_config1="${glidein_config}.$r.1"
+            local tmp_config2="${glidein_config}.$r.2"
+
+            # Copy the glidein config so it doesn't get modified while we grep out the old value
+            if ! cp -p "${glidein_config}" "${tmp_config1}"; then
+                warn "Error writing ${tmp_config1}"
+                rm -f "${tmp_config1}"
+                exit 1
+            fi
+            grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
+            rm -f "${tmp_config1}"
+            if [ ! -f "${tmp_config2}" ]; then
+                warn "Error creating ${tmp_config2}"
+                exit 1
+            fi
+            # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
+            echo "$@" >> "${tmp_config2}"
+
+            # Replace glidein config atomically
+            if ! mv -f "${tmp_config2}" "${glidein_config}"; then
+                warn "Error updating ${glidein_config} from ${tmp_config2}"
+                rm -f "${tmp_config2}"
+                exit 1
+            fi
+        fi
+    }
+    # XXX End add_config_line() patch
 fi
 
 # source our helpers


### PR DESCRIPTION
This is the same code copy-pasted; it should be removed once the change goes upstream.