### PR TITLE
Add sentinel line to itb-osgvo-advertise-base so it only writes to $glidein_config on the first run

### DIFF
--- a/node-check/itb-osgvo-advertise-base
+++ b/node-check/itb-osgvo-advertise-base
@@ -185,6 +185,10 @@ if [ "x$glidein_config" = "x" ]; then
     info "No arguments provided - assuming HTCondor startd cron mode"
 else
     info "Arguments to the script: $@"
+    if grep '^OSGVO_ADVERTISE_BASE_DONE ' $glidein_config; then
+        info "OSGVO_ADVERTISE_BASE_DONE sentinel found: not doing any more writes"
+        glidein_config="NONE"
+    fi
 fi
 
 if [ "$glidein_config" != "NONE" ]; then
@@ -596,6 +600,12 @@ else
 fi
 
 ##################
+
+# Add config line sentinel; subsequent runs will test for this and not modify the glidein config if set.
+if [ "$glidein_config" != "NONE" ]; then
+    add_config_line_safe OSGVO_ADVERTISE_BASE_DONE True
+fi
+
 rm -f $PID_FILE
 info "All done - time to do some real work!"
 


### PR DESCRIPTION
You can't tell from command-line arguments if you're running in a startd cron because [script_wrapper.sh](https://github.com/glideinWMS/glideinwms/blob/v3_9_5/creation/web_base/script_wrapper.sh) calls [itb-]osgvo-advertise-base and gives it the glidein config.