### PR TITLE
Merge ITB script changes to production and bump OSG_GLIDEIN_VERSION to 628

### DIFF
--- a/node-check/osgvo-additional-htcondor-config
+++ b/node-check/osgvo-additional-htcondor-config
@@ -8,6 +8,41 @@ glidein_config="$1"
 add_config_line_source=`grep '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}'`
 source $add_config_line_source
 
+# Patch over add_config_line() with a safer version
+add_config_line() {
+    # Ignore the call if the exact config line is already in there
+    if ! grep -q "^${*}$" "${glidein_config}"; then
+        # Use temporary files to make sure multiple add_config_line() calls don't clobber
+        # the glidein_config.
+        local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
+        local tmp_config1="${glidein_config}.$r.1"
+        local tmp_config2="${glidein_config}.$r.2"
+
+        # Copy the glidein config so it doesn't get modified while we grep out the old value
+        if ! cp -p "${glidein_config}" "${tmp_config1}"; then
+            warn "Error writing ${tmp_config1}"
+            rm -f "${tmp_config1}"
+            exit 1
+        fi
+        grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
+        rm -f "${tmp_config1}"
+        if [ ! -f "${tmp_config2}" ]; then
+            warn "Error creating ${tmp_config2}"
+            exit 1
+        fi
+        # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
+        echo "$@" >> "${tmp_config2}"
+
+        # Replace glidein config atomically
+        if ! mv -f "${tmp_config2}" "${glidein_config}"; then
+            warn "Error updating ${glidein_config} from ${tmp_config2}"
+            rm -f "${tmp_config2}"
+            exit 1
+        fi
+    fi
+}
+# End add_config_line() patch
+
 condor_vars_file=`grep -i "^CONDOR_VARS_FILE " $glidein_config | awk '{print $2}'`
 
 ###########################################################

--- a/node-check/osgvo-advertise-base
+++ b/node-check/osgvo-advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=624
+OSG_GLIDEIN_VERSION=628
 #######################################################################
 
 
@@ -184,7 +184,11 @@ if [ "x$glidein_config" = "x" ]; then
     glidein_config="NONE"
     info "No arguments provided - assuming HTCondor startd cron mode"
 else
-    info "Arguments to the script: $@"
+    info "Arguments to the script: $*"
+    if [ -e "$glidein_config.saved" ]; then
+        info "$glidein_config.saved found; not doing any more writes"
+        glidein_config="NONE"
+    fi
 fi
 
 if [ "$glidein_config" != "NONE" ]; then
@@ -201,6 +205,41 @@ if [ "$glidein_config" != "NONE" ]; then
 
     info "Sourcing $add_config_line_source"
     source $add_config_line_source
+
+    # XXX Patch over add_config_line() with a safer version
+    add_config_line() {
+        # Ignore the call if the exact config line is already in there
+        if ! grep -q "^${*}$" "${glidein_config}"; then
+            # Use temporary files to make sure multiple add_config_line() calls don't clobber
+            # the glidein_config.
+            local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
+            local tmp_config1="${glidein_config}.$r.1"
+            local tmp_config2="${glidein_config}.$r.2"
+
+            # Copy the glidein config so it doesn't get modified while we grep out the old value
+            if ! cp -p "${glidein_config}" "${tmp_config1}"; then
+                warn "Error writing ${tmp_config1}"
+                rm -f "${tmp_config1}"
+                exit 1
+            fi
+            grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
+            rm -f "${tmp_config1}"
+            if [ ! -f "${tmp_config2}" ]; then
+                warn "Error creating ${tmp_config2}"
+                exit 1
+            fi
+            # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
+            echo "$@" >> "${tmp_config2}"
+
+            # Replace glidein config atomically
+            if ! mv -f "${tmp_config2}" "${glidein_config}"; then
+                warn "Error updating ${glidein_config} from ${tmp_config2}"
+                rm -f "${tmp_config2}"
+                exit 1
+            fi
+        fi
+    }
+    # XXX End add_config_line() patch
 fi
 
 # timeout, if available, is used across many tests
@@ -561,6 +600,13 @@ else
 fi
 
 ##################
+
+# Save a backup copy of glidein_config that won't get clobbered by startd_crons; also use this as a sentinel
+# so subsequent runs of this script won't modify glidein_config if it exists.
+if [[ $glidein_config != "NONE" && ! -e "$glidein_config.saved" ]]; then
+    cp -p "$glidein_config" "$glidein_config.saved"
+fi
+
 rm -f $PID_FILE
 info "All done - time to do some real work!"
 

--- a/node-check/osgvo-advertise-userenv
+++ b/node-check/osgvo-advertise-userenv
@@ -153,6 +153,41 @@ if [ "$glidein_config" != "NONE" ]; then
 
     info "Sourcing $add_config_line_source"
     source $add_config_line_source
+
+    # XXX Patch over add_config_line() with a safer version
+    add_config_line() {
+        # Ignore the call if the exact config line is already in there
+        if ! grep -q "^${*}$" "${glidein_config}"; then
+            # Use temporary files to make sure multiple add_config_line() calls don't clobber
+            # the glidein_config.
+            local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
+            local tmp_config1="${glidein_config}.$r.1"
+            local tmp_config2="${glidein_config}.$r.2"
+
+            # Copy the glidein config so it doesn't get modified while we grep out the old value
+            if ! cp -p "${glidein_config}" "${tmp_config1}"; then
+                warn "Error writing ${tmp_config1}"
+                rm -f "${tmp_config1}"
+                exit 1
+            fi
+            grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
+            rm -f "${tmp_config1}"
+            if [ ! -f "${tmp_config2}" ]; then
+                warn "Error creating ${tmp_config2}"
+                exit 1
+            fi
+            # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
+            echo "$@" >> "${tmp_config2}"
+
+            # Replace glidein config atomically
+            if ! mv -f "${tmp_config2}" "${glidein_config}"; then
+                warn "Error updating ${glidein_config} from ${tmp_config2}"
+                rm -f "${tmp_config2}"
+                exit 1
+            fi
+        fi
+    }
+    # XXX End add_config_line() patch
 fi
 
 # timeout - need this early as we use it in some commands later

--- a/node-check/osgvo-default-image
+++ b/node-check/osgvo-default-image
@@ -159,6 +159,41 @@ if [ "$glidein_config" != "NONE" ]; then
     add_config_line_source=$PWD/add_config_line.source
 
     source $add_config_line_source
+
+    # XXX Patch over add_config_line() with a safer version
+    add_config_line() {
+        # Ignore the call if the exact config line is already in there
+        if ! grep -q "^${*}$" "${glidein_config}"; then
+            # Use temporary files to make sure multiple add_config_line() calls don't clobber
+            # the glidein_config.
+            local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
+            local tmp_config1="${glidein_config}.$r.1"
+            local tmp_config2="${glidein_config}.$r.2"
+
+            # Copy the glidein config so it doesn't get modified while we grep out the old value
+            if ! cp -p "${glidein_config}" "${tmp_config1}"; then
+                warn "Error writing ${tmp_config1}"
+                rm -f "${tmp_config1}"
+                exit 1
+            fi
+            grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
+            rm -f "${tmp_config1}"
+            if [ ! -f "${tmp_config2}" ]; then
+                warn "Error creating ${tmp_config2}"
+                exit 1
+            fi
+            # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
+            echo "$@" >> "${tmp_config2}"
+
+            # Replace glidein config atomically
+            if ! mv -f "${tmp_config2}" "${glidein_config}"; then
+                warn "Error updating ${glidein_config} from ${tmp_config2}"
+                rm -f "${tmp_config2}"
+                exit 1
+            fi
+        fi
+    }
+    # XXX End add_config_line() patch
 fi
 
 # source our helpers

--- a/node-check/singularity-extras
+++ b/node-check/singularity-extras
@@ -41,6 +41,41 @@ if [ "$glidein_config" != "NONE" ]; then
 
     info "Sourcing $add_config_line_source"
     source $add_config_line_source
+
+    # XXX Patch over add_config_line() with a safer version
+    add_config_line() {
+        # Ignore the call if the exact config line is already in there
+        if ! grep -q "^${*}$" "${glidein_config}"; then
+            # Use temporary files to make sure multiple add_config_line() calls don't clobber
+            # the glidein_config.
+            local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
+            local tmp_config1="${glidein_config}.$r.1"
+            local tmp_config2="${glidein_config}.$r.2"
+
+            # Copy the glidein config so it doesn't get modified while we grep out the old value
+            if ! cp -p "${glidein_config}" "${tmp_config1}"; then
+                warn "Error writing ${tmp_config1}"
+                rm -f "${tmp_config1}"
+                exit 1
+            fi
+            grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
+            rm -f "${tmp_config1}"
+            if [ ! -f "${tmp_config2}" ]; then
+                warn "Error creating ${tmp_config2}"
+                exit 1
+            fi
+            # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
+            echo "$@" >> "${tmp_config2}"
+
+            # Replace glidein config atomically
+            if ! mv -f "${tmp_config2}" "${glidein_config}"; then
+                warn "Error updating ${glidein_config} from ${tmp_config2}"
+                rm -f "${tmp_config2}"
+                exit 1
+            fi
+        fi
+    }
+    # XXX End add_config_line() patch
 fi
 
 # source our helpers


### PR DESCRIPTION
- Save a copy of the glidein_config before it might be clobbered by startd_crons; prefer this saved copy in the job wrapper
- Use $glidein_config.saved as a sentinel file for whether [itb-]osgvo-advertise-base should write anything to the glidein config
- Patch over add_config_line() with a safer version that is less likely to stomp over the glidein_config when run concurrently