### PR TITLE
ITB: Fix units for "RESERVED_DISK"

### DIFF
--- a/node-check/itb-osgvo-additional-htcondor-config
+++ b/node-check/itb-osgvo-additional-htcondor-config
@@ -59,7 +59,8 @@ add_config_line HasExcessiveLoad "LoadAvg > 2*DetectedCpus + 2"
 add_condor_vars_line HasExcessiveLoad "C" "-" "+" "N" "Y" "-"
 
 # out of disk space (https://opensciencegrid.atlassian.net/browse/OSPOOL-4)
-add_config_line RESERVED_DISK "3000000"
+# note: Unlike DISK, RESERVED_DISK is in megabytes
+add_config_line RESERVED_DISK "3000"
 add_condor_vars_line RESERVED_DISK "C" "-" "+" "N" "N" "-"
 
 # use df and allocated cores to determine disk allocation (https://opensciencegrid.atlassian.net/browse/OSPOOL-5)


### PR DESCRIPTION
It should be in MB, not KB, and a Condor bug causes a weird value if RESERVED_DISK is greater than available