### PR TITLE
Fix RESERVED_DISK in osgvo scripts

### DIFF
--- a/node-check/osgvo-additional-htcondor-config
+++ b/node-check/osgvo-additional-htcondor-config
@@ -59,7 +59,8 @@ add_config_line HasExcessiveLoad "LoadAvg > 2*DetectedCpus + 2"
 add_condor_vars_line HasExcessiveLoad "C" "-" "+" "N" "Y" "-"
 
 # out of disk space (https://opensciencegrid.atlassian.net/browse/OSPOOL-4)
-add_config_line RESERVED_DISK "3000000"
+# note: Unlike DISK, RESERVED_DISK is in megabytes
+add_config_line RESERVED_DISK "3000"
 add_condor_vars_line RESERVED_DISK "C" "-" "+" "N" "N" "-"
 
 # use df and allocated cores to determine disk allocation (https://opensciencegrid.atlassian.net/browse/OSPOOL-5)


### PR DESCRIPTION
(OPS-315)

Same as #165, but for production