### PR TITLE
Add stashcp/stashplugin to IGWN pilots

### DIFF
--- a/node-check/igwn-additional-htcondor-config
+++ b/node-check/igwn-additional-htcondor-config
@@ -64,8 +64,8 @@ chmod 755 $STASHCP $STASH_PLUGIN
 # also run a simple test (what should this be?)
 #if ($TIMEOUT $STASHCP /osgconnect/public/dweitzel/stashcp/test.file stashcp-test.file) &>/dev/null &&
 #   [[ $OSG_SITE_NAME != "UTC-Epyc" ]]; then
-#    add_config_line FILETRANSFER_PLUGINS "\$(FILETRANSFER_PLUGINS),$STASH_PLUGIN"
-#    add_condor_vars_line FILETRANSFER_PLUGINS "C" "-" "+" "N" "N" "-"
+    add_config_line FILETRANSFER_PLUGINS "\$(FILETRANSFER_PLUGINS),$STASH_PLUGIN"
+    add_condor_vars_line FILETRANSFER_PLUGINS "C" "-" "+" "N" "N" "-"
 #fi
 
 echo "All done (igwn-additional-htcondor-config)"

--- a/node-check/igwn-additional-htcondor-config
+++ b/node-check/igwn-additional-htcondor-config
@@ -51,21 +51,21 @@ STASHCP=$PWD/client/stashcp
 STASH_PLUGIN=$PWD/client/stash_plugin
 chmod 755 $STASHCP $STASH_PLUGIN
 
-#TIMEOUT=$(which timeout 2>/dev/null)
-#if [ "x$TIMEOUT" != "x" ]; then
-#    TIMEOUT="$TIMEOUT 10s"
-#fi
-#
-#glidein_site=`grep -i "^GLIDEIN_Site " $glidein_config | awk '{print $2}'`
-#if [[ -z $OSG_SITE_NAME ]]; then
-#    OSG_SITE_NAME=$glidein_site
-#fi
-#
-# also run a simple test (what should this be?)
-#if ($TIMEOUT $STASHCP /osgconnect/public/dweitzel/stashcp/test.file stashcp-test.file) &>/dev/null &&
-#   [[ $OSG_SITE_NAME != "UTC-Epyc" ]]; then
+TIMEOUT=$(which timeout 2>/dev/null)
+if [ "x$TIMEOUT" != "x" ]; then
+    TIMEOUT="$TIMEOUT 10s"
+fi
+
+glidein_site=`grep -i "^GLIDEIN_Site " $glidein_config | awk '{print $2}'`
+if [[ -z $OSG_SITE_NAME ]]; then
+    OSG_SITE_NAME=$glidein_site
+fi
+
+# also run a simple test (TODO: make this IGWN-specific)
+if ($TIMEOUT $STASHCP /osgconnect/public/dweitzel/stashcp/test.file stashcp-test.file) &>/dev/null &&
+   [[ $OSG_SITE_NAME != "UTC-Epyc" ]]; then
     add_config_line FILETRANSFER_PLUGINS "\$(FILETRANSFER_PLUGINS),$STASH_PLUGIN"
     add_condor_vars_line FILETRANSFER_PLUGINS "C" "-" "+" "N" "N" "-"
-#fi
+fi
 
 echo "All done (igwn-additional-htcondor-config)"

--- a/node-check/igwn-additional-htcondor-config
+++ b/node-check/igwn-additional-htcondor-config
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+glidein_config="$1"
+
+###########################################################
+# import add_config_line and add_condor_vars_line functions
+
+add_config_line_source=`grep '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}'`
+source $add_config_line_source
+
+# Patch over add_config_line() with a safer version
+add_config_line() {
+    # Ignore the call if the exact config line is already in there
+    if ! grep -q "^${*}$" "${glidein_config}"; then
+        # Use temporary files to make sure multiple add_config_line() calls don't clobber
+        # the glidein_config.
+        local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
+        local tmp_config1="${glidein_config}.$r.1"
+        local tmp_config2="${glidein_config}.$r.2"
+
+        # Copy the glidein config so it doesn't get modified while we grep out the old value
+        if ! cp -p "${glidein_config}" "${tmp_config1}"; then
+            warn "Error writing ${tmp_config1}"
+            rm -f "${tmp_config1}"
+            exit 1
+        fi
+        grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
+        rm -f "${tmp_config1}"
+        if [ ! -f "${tmp_config2}" ]; then
+            warn "Error creating ${tmp_config2}"
+            exit 1
+        fi
+        # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
+        echo "$@" >> "${tmp_config2}"
+
+        # Replace glidein config atomically
+        if ! mv -f "${tmp_config2}" "${glidein_config}"; then
+            warn "Error updating ${glidein_config} from ${tmp_config2}"
+            rm -f "${tmp_config2}"
+            exit 1
+        fi
+    fi
+}
+# End add_config_line() patch
+
+condor_vars_file=`grep -i "^CONDOR_VARS_FILE " $glidein_config | awk '{print $2}'`
+
+###########################################################
+# stashcp 
+STASHCP=$PWD/client/stashcp
+STASH_PLUGIN=$PWD/client/stash_plugin
+chmod 755 $STASHCP $STASH_PLUGIN
+
+#TIMEOUT=$(which timeout 2>/dev/null)
+#if [ "x$TIMEOUT" != "x" ]; then
+#    TIMEOUT="$TIMEOUT 10s"
+#fi
+#
+#glidein_site=`grep -i "^GLIDEIN_Site " $glidein_config | awk '{print $2}'`
+#if [[ -z $OSG_SITE_NAME ]]; then
+#    OSG_SITE_NAME=$glidein_site
+#fi
+#
+# also run a simple test (what should this be?)
+#if ($TIMEOUT $STASHCP /osgconnect/public/dweitzel/stashcp/test.file stashcp-test.file) &>/dev/null &&
+#   [[ $OSG_SITE_NAME != "UTC-Epyc" ]]; then
+#    add_config_line FILETRANSFER_PLUGINS "\$(FILETRANSFER_PLUGINS),$STASH_PLUGIN"
+#    add_condor_vars_line FILETRANSFER_PLUGINS "C" "-" "+" "N" "N" "-"
+#fi
+
+echo "All done (igwn-additional-htcondor-config)"


### PR DESCRIPTION
Following `osgvo-additional-htcondor-config`. To be enabled on the FE with:

```
      <file absfname="/opt/osg-flock/stashcp/stashcp" after_entry="False" after_group="False" const="True" executable="False" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="False">
         <untar_options cond_attr="TRUE"/>
      </file>
      <file absfname="/opt/osg-flock/stashcp/stash_plugin" after_entry="False" after_group="False" const="True" executable="False" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="False">
         <untar_options cond_attr="TRUE"/>
      </file>
      <file absfname="/opt/osg-flock/node-check/igwn-additional-htcondor-config" after_entry="True" after_group="False" const="True" executable="True" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="False">
         <untar_options cond_attr="TRUE"/>
      </file>
```

If this should go somewhere else, let me know. Also not sure how to add a test here, I assume `/osgconnect` will not be available in IGWN pilots.