### PR TITLE
Revert deletion of condor_vars_file definition

### DIFF
--- a/node-check/igwn-additional-htcondor-config
+++ b/node-check/igwn-additional-htcondor-config
@@ -51,6 +51,8 @@ add_config_line() {
 }
 # End add_config_line() patch
 
+condor_vars_file=`grep -i "^CONDOR_VARS_FILE " $glidein_config | awk '{print $2}'`
+
 ###########################################################
 # stashcp 
 STASHCP=$PWD/client/stashcp


### PR DESCRIPTION
This (unused) variable is apparently important?

After deleting line defining `condor_vars_file` in last commit, started getting errors like:

```
mv: cannot stat '': No such file or directory
Thu Oct  6 05:59:24 PDT 2022 Error renaming  into .old
```

This reverts that change.