### PR TITLE
override singularity_exec in wip-job-wrappers, too (SOFTWARE-5340)

### DIFF
--- a/job-wrappers/default_singularity_wrapper.sh
+++ b/job-wrappers/default_singularity_wrapper.sh
@@ -326,6 +326,8 @@ singularity_exec() {
     # Out:
     # Return:
     #  string w/ command options on stdout
+    # Uses:
+    #  SINGULARITY_DISABLE_PID_NAMESPACES
 
     local singularity_bin="$1"
     local singularity_image="$2"
@@ -333,8 +335,7 @@ singularity_exec() {
     # Keeping --contain. Should not interfere w/ GPUs
     local singularity_opts="--ipc --contain $4"  # extra options added at the end (still before binds)
     # add --pid if not disabled in config
-    no_pid_ns=$(get_glidein_config_value DISABLE_SINGULARITY_PID_NAMESPACES)
-    [[ $no_pid_ns = 1 ]] || singularity_opts+=" --pid"
+    [[ $(gwms_from_config SINGULARITY_DISABLE_PID_NAMESPACES) = 1 ]] || singularity_opts+=" --pid"
     local singularity_global_opts="$5"
     local execution_opt="$6"
     [[ -z "$singularity_image"  ||  -z "$singularity_bin" ]] && { warn "Singularity image or binary empty. Failing to run Singularity "; false; return; }

--- a/job-wrappers/itb-default_singularity_wrapper.sh
+++ b/job-wrappers/itb-default_singularity_wrapper.sh
@@ -326,6 +326,8 @@ singularity_exec() {
     # Out:
     # Return:
     #  string w/ command options on stdout
+    # Uses:
+    #  SINGULARITY_DISABLE_PID_NAMESPACES
 
     local singularity_bin="$1"
     local singularity_image="$2"
@@ -333,8 +335,7 @@ singularity_exec() {
     # Keeping --contain. Should not interfere w/ GPUs
     local singularity_opts="--ipc --contain $4"  # extra options added at the end (still before binds)
     # add --pid if not disabled in config
-    no_pid_ns=$(get_glidein_config_value DISABLE_SINGULARITY_PID_NAMESPACES)
-    [[ $no_pid_ns = 1 ]] || singularity_opts+=" --pid"
+    [[ $(gwms_from_config SINGULARITY_DISABLE_PID_NAMESPACES) = 1 ]] || singularity_opts+=" --pid"
     local singularity_global_opts="$5"
     local execution_opt="$6"
     [[ -z "$singularity_image"  ||  -z "$singularity_bin" ]] && { warn "Singularity image or binary empty. Failing to run Singularity "; false; return; }

--- a/node-check/osgvo-node-advertise
+++ b/node-check/osgvo-node-advertise
@@ -612,8 +612,7 @@ if [ "x$GLIDEIN_Singularity_Use" = "x"  -o "x$GLIDEIN_Singularity_Use" = "xGWMS_
 
         OSG_SINGULARITY_EXTRA_OPTS="$OSG_SINGULARITY_EXTRA_OPTS --no-home --contain --ipc"
         # add --pid unless disabled in config
-        no_pid_ns=$(get_glidein_config_value DISABLE_SINGULARITY_PID_NAMESPACES)
-        [[ $no_pid_ns = 1 ]] || OSG_SINGULARITY_EXTRA_OPTS+=" --pid"
+        [[ $(gwms_from_config SINGULARITY_DISABLE_PID_NAMESPACES) = 1 ]] || OSG_SINGULARITY_EXTRA_OPTS+=" --pid"
 
         # Let's do a simple singularity test by echoing something inside, and then
         # grepping for it outside. This takes care of some errors which happen "late"

--- a/wip-job-wrappers/default_singularity_wrapper.sh
+++ b/wip-job-wrappers/default_singularity_wrapper.sh
@@ -326,6 +326,8 @@ singularity_exec() {
     # Out:
     # Return:
     #  string w/ command options on stdout
+    # Uses:
+    #  SINGULARITY_DISABLE_PID_NAMESPACES
 
     local singularity_bin="$1"
     local singularity_image="$2"
@@ -333,8 +335,7 @@ singularity_exec() {
     # Keeping --contain. Should not interfere w/ GPUs
     local singularity_opts="--ipc --contain $4"  # extra options added at the end (still before binds)
     # add --pid if not disabled in config
-    no_pid_ns=$(get_glidein_config_value DISABLE_SINGULARITY_PID_NAMESPACES)
-    [[ $no_pid_ns = 1 ]] || singularity_opts+=" --pid"
+    [[ $(gwms_from_config SINGULARITY_DISABLE_PID_NAMESPACES) = 1 ]] || singularity_opts+=" --pid"
     local singularity_global_opts="$5"
     local execution_opt="$6"
     [[ -z "$singularity_image"  ||  -z "$singularity_bin" ]] && { warn "Singularity image or binary empty. Failing to run Singularity "; false; return; }


### PR DESCRIPTION
Attn @rynge @brianhlin

We were overriding `singularity_exec` in the `default_singularity_wrapper.sh` and `itb-default_singularity_wrapper.sh` under `job-wrappers`, but not `wip-job-wrappers`.  This seems to be the only place that wasn't overriding this function.