### PR TITLE
Cleanup job environments in ITB

### DIFF
--- a/node-check/itb-osgvo-additional-htcondor-config
+++ b/node-check/itb-osgvo-additional-htcondor-config
@@ -194,6 +194,50 @@ else
     while read line; do warn "$line"; done < stashcp-test.log
 fi
 
+##################################################################
+# Generate a minimal `STARTER_JOB_ENVIRONMENT`, mostly composed of
+# informational variables that are considered safe to always leak to
+# the job environment.
+#
+# Source of OSG_* variables:
+#   https://github.com/opensciencegrid/osg-configure/blob/dcd02313500cf113e8a6c27571197b4803295774/scripts/osg-configure#L27
+# Removed the following ones that don't appear actively used anymore:
+#  OSG_GRID, OSG_APP, OSG_DATA, OSG_SITE_READ, OSG_SITE_WRITE
+# Removed $OSG_WN_TMP because any job should use the HTCondor-provided scratch dir.
+# Considered and not passed through:
+#   LANG
+info "Calculating default job environment variables."
+
+job_env=
+for envvar in \
+     OSG_SITE_NAME \
+     OSG_HOSTNAME \
+     OSG_SQUID_LOCATION \
+     http_proxy \
+     https_proxy \
+     FTP_PROXY \
+     X509_USER_PROXY \
+; do
+
+if [ ! -z ${!envvar+x} ]; then
+  condor_env_entry="$envvar=${!envvar}"
+  condor_env_entry=$(echo "$condor_env_entry" | awk '{gsub(/"/,"\"\""); print}')
+  condor_env_entry=$(echo "$condor_env_entry" | awk "{gsub(/'/,\"''\"); print}")
+  if [[ -z "$job_env" ]]; then
+    job_env="'$condor_env_entry'"
+  else
+    job_env="$job_env '$condor_env_entry'"
+  fi
+fi
+
+echo "Built default job environment: $job_env"
+
+add_config_line STARTER_JOB_ENVIRONMENT "\$(STARTER_JOB_ENVIRONMENT) $job_env"
+add_condor_vars_line STARTER_JOB_ENVIRONMENT "C" "-" "+" "N" "N" "-"
+
+done
+
+
 ###########################################################
 
 echo "All done (osgvo-additional-htcondor-config)"


### PR DESCRIPTION
This PR disables the behavior where we inherit the glidein's environment into the job.  Ideally, this allows us to remove environment cleaning code from within the USER_JOB_WRAPPER.