### PR TITLE
Factor out singularity image selection to a prepare job hook

### DIFF
--- a/job-wrappers/itb-simple-job-wrapper.sh
+++ b/job-wrappers/itb-simple-job-wrapper.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# If we're inside Singularity, then make sure we set HOME and IWD correctly.
+# (N.B. - it's not 100% clear that this is needed.  Original comments around
+# this note that `--pwd` is unreliable in some versions of Singularity but not
+# when this was fixed.
+if [ ! -z "$SINGULARITY_NAME" ]; then
+    [[ -d /srv ]] && cd /srv
+    export HOME=/srv
+    export OSG_WN_TMP=/tmp
+else
+    # OSPool: set up TMPDIR to be in the job dir; try to avoid /tmp at
+    # sites as some users tend to fill it up and disrupt the host.
+    #
+    # This is not done when inside Singularity as the equivalent is accomplished
+    # via bind mounts.
+    if [ "x$_CONDOR_SCRATCH_DIR" != "x" ]; then
+        TMPDIR="$_CONDOR_SCRATCH_DIR/.local-tmp"
+    else
+        TMPDIR=$(pwd)"/.local-tmp"
+    fi
+    export TMPDIR
+    export OSG_WN_TMP=$TMPDIR
+    mkdir -p $TMPDIR
+
+fi
+
+# Always make sure we have a reasonable PATH if it is not otherwise set.
+# Should be valid both inside and outside the container.
+export PATH=$PATH
+[[ -z "$PATH" ]] && export PATH="/usr/local/bin:/usr/bin:/bin"
+
+# GlideinWMS utility files and libraries - particularly condor_chirp
+if [[ -d "$PWD/.gwms.d/bin" ]]; then
+    # This includes the portable Python only condor_chirp
+    export PATH="$PWD/$GWMS_SUBDIR/bin:$PATH"
+fi
+
+# Some java programs have seen problems with the timezone in our containers.
+# If not already set, provide a default TZ
+[[ -z "$TZ" ]] && export TZ="UTC"
+
+exec "$@"

--- a/node-check/itb-osgvo-additional-htcondor-config
+++ b/node-check/itb-osgvo-additional-htcondor-config
@@ -235,6 +235,8 @@ add_config_line "OSPOOL_HOOK_PREPARE_JOB" "$glidein_dir/client_group_main/itb-pr
 add_condor_vars_line "OSPOOL_HOOK_PREPARE_JOB" "C" "-" "OSPOOL_HOOK_PREPARE_JOB" "N" "N" "-"
 add_config_line "STARTER_JOB_HOOK_KEYWORD" "OSPOOL"
 add_condor_vars_line "STARTER_JOB_HOOK_KEYWORD" "C" "-" "STARTER_JOB_HOOK_KEYWORD" "N" "N" "-"
+add_config_line "OSPOOL_HOOK_PREPARE_JOB_TIMEOUT" "900"
+add_condor_vars_line "OSPOOL_HOOK_PREPARE_JOB_TIMEOUT" "C" "-" "OSPOOL_HOOK_PREPARE_JOB_TIMEOUT" "N" "N" "-"
 
 ###########################################################
 

--- a/node-check/itb-osgvo-additional-htcondor-config
+++ b/node-check/itb-osgvo-additional-htcondor-config
@@ -226,6 +226,15 @@ fi
 
 done
 
+###########################################################
+# Add prepare hook to do the OSPool-specific transform of
+# the Singularity container outside of the glidein default
+# image.
+glidein_dir=`grep -i "^GLIDECLIENT_GROUP_WORK_DIR " $glidein_config | awk '{print $2}'`
+add_config_line "OSPOOL_HOOK_PREPARE_JOB" "$glidein_dir/client_group_main/itb-prepare-hook-lib"
+add_condor_vars_line "OSPOOL_HOOK_PREPARE_JOB" "C" "-" "OSPOOL_HOOK_PREPARE_JOB" "N" "N" "-"
+add_config_line "STARTER_JOB_HOOK_KEYWORD" "OSPOOL"
+add_condor_vars_line "STARTER_JOB_HOOK_KEYWORD" "C" "-" "STARTER_JOB_HOOK_KEYWORD" "N" "N" "-"
 
 ###########################################################
 

--- a/node-check/itb-prepare-hook-lib
+++ b/node-check/itb-prepare-hook-lib
@@ -47,7 +47,6 @@ exit_wrapper () {
     # signal other parts of the glidein that it is time to stop accepting jobs
     touch $GWMS_THIS_SCRIPT_DIR/stop-glidein.stamp >/dev/null 2>&1
 
-    [[ -n "$publish_fail" ]] && warn "Failed to communicate ERROR with ${publish_fail}"
 
     # Eventually the periodic validation of singularity will make the pilot
     # to stop matching new payloads

--- a/node-check/itb-prepare-hook-lib
+++ b/node-check/itb-prepare-hook-lib
@@ -1,0 +1,579 @@
+#!/bin/bash
+#
+# OSPool / GlideinWMS helper functions.
+#
+# Used for the prepare job hook, particularly to select an appropriate Singularity image
+#
+GWMS_THIS_SCRIPT="$0"
+GWMS_THIS_SCRIPT_DIR=$(readlink -f $(dirname "$0")/..)
+EXITSLEEP=10m
+
+# Directory in Singularity where auxiliary files are copied (e.g. singularity_lib.sh)
+GWMS_AUX_SUBDIR=${GWMS_AUX_SUBDIR:-".gwms_aux"}
+export GWMS_AUX_SUBDIR
+
+# GWMS_BASE_SUBDIR (directory where the base glidein directory is mounted) not defiled in Singularity for the user jobs, only for setup scripts
+# Directory to use for bin, lib, exec, ...
+GWMS_SUBDIR=${GWMS_SUBDIR:-".gwms.d"}
+export GWMS_SUBDIR
+
+# CVMFS_BASE defaults to /cvmfs but can be overridden in case of for example cvmfsexec
+if [ "x$CVMFS_BASE" = "x" ]; then
+    CVMFS_BASE="/cvmfs"
+fi
+
+# Manage GWMS debug and info messages in the stdout/err (unless userjob option is set)
+#[[ ! ",${GLIDEIN_DEBUG_OPTIONS}," = *,userjob,* ]] && GLIDEIN_QUIET=True
+[[ ! ",${GLIDEIN_DEBUG_OPTIONS}," = *,nowait,* ]] && EXITSLEEP=2m  # leave 2min to update classad
+GLIDEIN_DEBUG_OUTPUT=1
+
+# When failing we need to tell HTCondor to put the job back in the queue by creating
+# a file in the PATH pointed by $_CONDOR_WRAPPER_ERROR_FILE
+# Make sure there is no leftover wrapper error file (if the file exists HTCondor assumes the wrapper failed)
+[[ -n "$_CONDOR_WRAPPER_ERROR_FILE" ]] && rm -f "$_CONDOR_WRAPPER_ERROR_FILE" >/dev/null 2>&1 || true
+
+
+exit_wrapper () {
+    # An error occurred. Communicate to HTCondor and avoid black hole (sleep for hold time) and then exit 1
+    #  1: Error message
+    #  2: Exit code (1 by default)
+    #  3: sleep time (default: $EXITSLEEP)
+    # The error is published to stderr, if available to $_CONDOR_WRAPPER_ERROR_FILE,
+    # if chirp available sets JobWrapperFailure
+    [[ -n "$1" ]] && warn_raw "ERROR: $1"
+    local exit_code=${2:-1}
+    local sleep_time=${3:-$EXITSLEEP}
+
+    # signal other parts of the glidein that it is time to stop accepting jobs
+    touch $GWMS_THIS_SCRIPT_DIR/stop-glidein.stamp >/dev/null 2>&1
+
+    [[ -n "$publish_fail" ]] && warn "Failed to communicate ERROR with ${publish_fail}"
+
+    # Eventually the periodic validation of singularity will make the pilot
+    # to stop matching new payloads
+    # Prevent a black hole by sleeping EXITSLEEP (10) minutes before exiting. Sleep time can be changed on top of this file
+    sleep $sleep_time
+    exit $exit_code
+}
+
+# In case singularity_lib cannot be imported
+warn_raw () {
+    echo "$@" 1>&2
+}
+
+# Ensure all jobs have PATH set
+# bash can set a default PATH - make sure it is exported
+export PATH=$PATH
+[[ -z "$PATH" ]] && export PATH="/usr/local/bin:/usr/bin:/bin"
+
+[[ -z "$glidein_config" ]] && [[ -e "$GWMS_THIS_SCRIPT_DIR/glidein_config" ]] &&
+    export glidein_config="$GWMS_THIS_SCRIPT_DIR/glidein_config"
+
+# error_gen defined also in singularity_lib.sh
+[[ -e "$glidein_config" ]] && error_gen="$(grep '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-)"
+
+# Source utility files, outside and inside Singularity
+# condor_job_wrapper is in the base directory, singularity_lib.sh in main
+# and copied to RUNDIR/$GWMS_AUX_SUBDIR (RUNDIR becomes /srv in Singularity)
+if [[ -e "$GWMS_THIS_SCRIPT_DIR/main/singularity_lib.sh" ]]; then
+    GWMS_AUX_DIR="$GWMS_THIS_SCRIPT_DIR/main"
+elif [[ -e /srv/$GWMS_AUX_SUBDIR/singularity_lib.sh ]]; then
+    # In Singularity
+    GWMS_AUX_DIR="/srv/$GWMS_AUX_SUBDIR"
+else
+    echo "ERROR: $GWMS_THIS_SCRIPT: Unable to source singularity_lib.sh! File not found. Quitting" 1>&2
+    warn=warn_raw
+    exit_wrapper "Wrapper script $GWMS_THIS_SCRIPT failed: Unable to source singularity_lib.sh" 1
+fi
+# shellcheck source=../singularity_lib.sh
+. "${GWMS_AUX_DIR}"/singularity_lib.sh
+
+# Directory to use for bin, lib, exec, ... full path
+if [[ -n "$GWMS_DIR" && -e "$GWMS_DIR/bin" ]]; then
+    # already set, keep it
+    true
+elif [[ -e $GWMS_THIS_SCRIPT_DIR/$GWMS_SUBDIR/bin ]]; then
+    GWMS_DIR=$GWMS_THIS_SCRIPT_DIR/$GWMS_SUBDIR
+elif [[ -e /srv/$GWMS_SUBDIR/bin ]]; then
+    GWMS_DIR=/srv/$GWMS_SUBDIR
+elif [[ -e /srv/$(dirname "$GWMS_AUX_DIR")/$GWMS_SUBDIR/bin ]]; then
+    GWMS_DIR=/srv/$(dirname "$GWMS_AUX_DIR")/$GWMS_SUBDIR/bin
+else
+    echo "ERROR: $GWMS_THIS_SCRIPT: Unable to find GWMS_DIR! (GWMS_THIS_SCRIPT_DIR=$GWMS_THIS_SCRIPT_DIR GWMS_SUBDIR=$GWMS_SUBDIR)" 1>&2
+    exit_wrapper "Wrapper script $GWMS_THIS_SCRIPT failed: Unable to find GWMS_DIR! (GWMS_THIS_SCRIPT_DIR=$GWMS_THIS_SCRIPT_DIR GWMS_SUBDIR=$GWMS_SUBDIR)" 1
+fi
+export GWMS_DIR
+
+# Calculating full version number, including md5 sums form the wrapper and singularity_lib
+GWMS_VERSION_SINGULARITY_WRAPPER="${GWMS_VERSION_SINGULARITY_WRAPPER}_$(md5sum "$GWMS_THIS_SCRIPT" 2>/dev/null | cut -d ' ' -f1)_$(md5sum "${GWMS_AUX_DIR}/singularity_lib.sh" 2>/dev/null | cut -d ' ' -f1)"
+info_dbg "GWMS singularity wrapper ($GWMS_VERSION_SINGULARITY_WRAPPER) starting, $(date). Imported singularity_lib.sh. glidein_config ($glidein_config)."
+info_dbg "$GWMS_THIS_SCRIPT, in $(pwd), list: $(ls -al)"
+
+function get_glidein_config_value {
+    # extracts a config attribute value from
+    # $1 is the attribute key
+    CF=$glidein_config
+    if [ -e "$CF.saved" ]; then
+        CF=$CF.saved
+    fi
+    KEY="$1"
+    VALUE=`(cat $CF | grep "^$KEY " | tail -n 1 | sed "s/^$KEY //") 2>/dev/null`
+    echo "$VALUE"
+}
+
+# OS Pool helpers
+# source our helpers
+group_dir=$(get_glidein_config_value GLIDECLIENT_GROUP_WORK_DIR)
+if [ ! -d "$group_dir" ]; then
+    exit_wrapper "GLIDECLIENT_GROUP_WORK_DIR ($group_dir) is empty or not a directory" 1
+fi
+if [ -e "$group_dir/itb-ospool-lib" ]; then
+    source "$group_dir/itb-ospool-lib" || {
+        error_message="Unable to source itb-ospool-lib; group_dir is $group_dir; $(ls -ld "$group_dir" 2>&1); $(ls -ld "$group_dir/itb-ospool-lib" 2>&1)"
+        exit_wrapper "$error_message" 1
+    }
+else
+    source "$group_dir/ospool-lib" || {
+        error_message="Unable to source ospool-lib; group_dir is $group_dir; $(ls -ld "$group_dir" 2>&1); $(ls -ld "$group_dir/ospool-lib" 2>&1)"
+        exit_wrapper "$error_message" 1
+    }
+fi
+
+
+function download_or_build_singularity_image () {
+    local singularity_image="$1"
+
+    # ALLOW_NONCVMFS_IMAGES determines the approach here
+    # if it is 0, verify that the image is indeed on CVMFS
+    # if it is 1, transform the image to a form and try downloaded it from our services
+
+    # In addition, UNPACK_SIF determines whether a downloaded SIF image is
+    # expanded into the sandbox format (1) or used as-is (0).
+    info_dbg "Running download_or_build_singularity_image"
+
+    if [ "x$ALLOW_NONCVMFS_IMAGES" = "x0" ]; then
+        info_dbg "We do not allow non-CVMFS images"
+        if ! (echo "$singularity_image" | grep "^/cvmfs/") >/dev/null 2>&1; then
+            info_dbg "The specified image $singularity_image is not on CVMFS. Continuing anyways."
+            # allow this for now - we have user who ship images with their jobs
+            #return 1
+        fi
+    else
+        info_dbg "We allow non-CVMS images"
+        # first figure out a base image name in the form of owner/image:tag, then
+        # transform it to our expected image and name and try to download
+        singularity_srcs=""
+
+        if [[ $singularity_image = /cvmfs/singularity.opensciencegrid.org/* ]]; then
+            # transform /cvmfs to a set or URLS to to try
+            base_name=$(echo $singularity_image | sed 's;/cvmfs/singularity.opensciencegrid.org/;;' | sed 's;/*/$;;')
+            image_name=$(echo "$base_name" | sed 's;[:/];__;g')
+            week=$(date +'%V')
+            singularity_srcs="stash:///osgconnect/public/rynge/infrastructure/images/$week/sif/$image_name.sif https://data.isi.edu/osg/images/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
+        elif [[ -e "$singularity_image" ]]; then
+            # the image is not on cvmfs, but has already been downloaded - short circuit here
+            echo "$singularity_image"
+            return 0
+        else 
+            # user has been explicit with for example a docker or http URL
+            image_name=$(echo "$singularity_image" | sed 's;^[[:alnum:]]*://;;' | sed 's;[:/];__;g')
+            singularity_srcs="$singularity_image"
+        fi
+        # at this point image_name should be something like "opensciencegrid__osgvo-el8__latest"
+
+        local image_path="$GWMS_THIS_SCRIPT_DIR/images/$image_name"
+        info_dbg "Current image_path: $image_path"
+
+        # simple lock to prevent multiple slots from attempting dowloading of the same image
+        local lockfile="$image_path.lock"
+        (
+        flock -w 600 9
+
+        # already downloaded?
+        if [[ -e "$image_path" ]]; then
+            # even if we can use the sif, if we already have the sandbox, use that
+            echo "$image_path"
+            return 0
+        elif [[ -e "$image_path.sif" && $UNPACK_SIF = 0 ]]; then
+            # we already have the sif and we can use it
+            echo "$image_path.sif"
+            return 0
+        else
+            local tmptarget="$image_path.$$"
+            local logfile="$image_path.log"
+            local downloaded=0
+            rm -f $logfile
+
+            if [[ -e "$image_path.sif" && $UNPACK_SIF = 1 ]]; then
+                # we already have the sif but need to unpack it
+                # (this shouldn't happen very often)
+                if ("$GWMS_SINGULARITY_PATH" build --force --sandbox "$tmptarget" "$image_path.sif" ) &>>"$logfile"; then
+                    mv "$tmptarget" "$image_path"
+                    rm -f "$image_path.sif"
+                    echo "$image_path"
+                    return 0
+                else
+                    # unpack failed - sif may be damaged
+                    rm -f "$image_path.sif"
+                fi
+            fi
+
+            local tmptarget2
+            local image_path2
+            if [[ $UNPACK_SIF = 0 ]]; then
+                tmptarget2=$tmptarget.sif
+                image_path2=$image_path.sif
+            else
+                tmptarget2=$tmptarget
+                image_path2=$image_path
+            fi
+
+            for src in $singularity_srcs; do
+                echo "Trying to download from $src ..." &>>$logfile
+
+                if (echo "$src" | grep "^stash")>/dev/null 2>&1; then
+                    if (stash_download "$tmptarget2" "$src") &>>$logfile; then
+                        downloaded=1
+                        break
+                    fi
+
+                elif (echo "$src" | grep "^http")>/dev/null 2>&1; then
+                    if (http_download "$tmptarget2" "$src") &>>$logfile; then
+                        downloaded=1
+                        break
+                    fi
+
+                elif (echo "$src" | grep "^docker:" | grep -v "hub.opensciencegrid.org")>/dev/null 2>&1; then
+                    # docker is a special case - just pass it through
+                    # hub.opensciencegrid.org will be handled by "singularity build/pull" for now
+                    echo "$src"
+                    return 0
+
+                elif (echo "$src" | grep "://")>/dev/null 2>&1; then
+                    # some other url
+                    if [[ $UNPACK_SIF = 1 ]]; then
+                        if ($GWMS_SINGULARITY_PATH build --force --sandbox "$tmptarget2" "$src" ) &>>"$logfile"; then
+                            downloaded=1
+                            break
+                        fi
+                    else
+                        # "singularity pull" uses less CPU than "singularity build"
+                        # but $src must be a URL and it can't do --sandbox
+                        if ($GWMS_SINGULARITY_PATH pull --force "$tmptarget2" "$src" ) &>>"$logfile"; then
+                            downloaded=1
+                            break
+                        fi
+                    fi
+
+                else
+                    # we shouldn't have a local path at this point
+                    warn "Unexpected non-URL source '$src' for image $singularity_image"
+
+                fi
+                # clean up between attempts
+                rm -rf "$tmptarget2"
+            done
+            if [[ $downloaded = 1 ]]; then
+                mv "$tmptarget2" "$image_path2"
+            else
+                warn "Unable to download or build image ($singularity_image); logs:"
+                cat "$logfile" >&2
+                rm -rf "$tmptarget2"
+                return 1
+            fi
+            singularity_image=$image_path2
+        fi
+        ) 9>$lockfile
+        return $?
+    fi
+    echo "$singularity_image"
+    return 0
+}
+
+
+# OSPool - overriding this from singularity_lib.sh
+singularity_prepare_and_invoke() {
+    # Code moved into a function to allow early return in case of failure
+    # In case of failure: 1. it invokes singularity_exit_or_fallback which exits if Singularity is required
+    #   2. it interrupts itself and returns anyway
+    # The function returns in case the Singularity setup fails 
+    # In:
+    #   SINGULARITY_IMAGES_DICT: dictionary w/ Singularity images
+    #   $SINGULARITY_IMAGE_RESTRICTIONS: constraints on the Singularity image
+    # Using:
+    #   GWMS_SINGULARITY_IMAGE, 
+    #   or GWMS_SINGULARITY_IMAGE_RESTRICTIONS (SINGULARITY_IMAGES_DICT via singularity_get_image)
+    #      DESIRED_OS, GLIDEIN_REQUIRED_OS, REQUIRED_OS
+    #   $OSG_SITE_NAME (in monitoring)
+    #   GWMS_THIS_SCRIPT 
+    #   $GLIDEIN_Tmp_Dir GWMS_SINGULARITY_EXTRA_OPTS 
+    #   GWMS_SINGULARITY_OUTSIDE_PWD_LIST GWMS_SINGULARITY_OUTSIDE_PWD GWMS_THIS_SCRIPT_DIR _CONDOR_JOB_IWD
+    #   GWMS_BASE_SUBDIR - if defined will be bound to the glidein directory (will be accessible from singularity)
+    # Out:
+    #   GWMS_SINGULARITY_IMAGE GWMS_SINGULARITY_IMAGE_HUMAN GWMS_SINGULARITY_OUTSIDE_PWD_LIST SINGULARITY_WORKDIR GWMS_SINGULARITY_EXTRA_OPTS GWMS_SINGULARITY_REEXEC
+    # If  image is not provided, load the default one
+    # Custom URIs: http://singularity.lbl.gov/user-guide#supported-uris
+    
+    # Choose the singularity image
+    if [[ -z "$GWMS_SINGULARITY_IMAGE" ]]; then
+        # No image requested by the job
+        # Use OS matching to determine default; otherwise, set to the global default.
+        #  # Correct some legacy names? What if they are used in the dictionary?
+        #  REQUIRED_OS="`echo ",$REQUIRED_OS," | sed "s/,el7,/,rhel7,/;s/,el6,/,rhel6,/;s/,+/,/g;s/^,//;s/,$//"`"
+        DESIRED_OS=$(list_get_intersection "${GLIDEIN_REQUIRED_OS:-any}" "${REQUIRED_OS:-any}")
+        if [[ -z "$DESIRED_OS" ]]; then
+            msg="ERROR   VO (or job) REQUIRED_OS and Entry GLIDEIN_REQUIRED_OS have no intersection. Cannot select a Singularity image."
+            singularity_exit_or_fallback "$msg" 1
+            return
+        fi
+        if [[ "x$DESIRED_OS" = xany ]]; then
+            # Prefer the platforms default,rhel7,rhel6,rhel8, otherwise pick the first one available
+            GWMS_SINGULARITY_IMAGE=$(singularity_get_image default,rhel7,rhel6,rhel8 ${GWMS_SINGULARITY_IMAGE_RESTRICTIONS:+$GWMS_SINGULARITY_IMAGE_RESTRICTIONS,}any)
+        else
+            GWMS_SINGULARITY_IMAGE=$(singularity_get_image "$DESIRED_OS" $GWMS_SINGULARITY_IMAGE_RESTRICTIONS)
+        fi
+    fi
+
+    # At this point, GWMS_SINGULARITY_IMAGE is still empty, something is wrong
+    if [[ -z "$GWMS_SINGULARITY_IMAGE" ]]; then
+        msg="\
+ERROR   If you get this error when you did not specify required OS, your VO does not support any valid default Singularity image
+        If you get this error when you specified required OS, your VO does not support any valid image for that OS"
+        singularity_exit_or_fallback "$msg" 1
+        return
+    fi
+
+    # check that the image is actually available (but only for /cvmfs ones)
+    if cvmfs_path_in_cvmfs "$GWMS_SINGULARITY_IMAGE"; then
+        if ! ls -l "$GWMS_SINGULARITY_IMAGE" >/dev/null; then
+            msg="\
+ERROR   Unable to access the Singularity image: $GWMS_SINGULARITY_IMAGE
+        Site and node: $OSG_SITE_NAME $(hostname -f)"
+            singularity_exit_or_fallback "$msg" 1 10m
+            return
+        fi
+    fi
+
+    if [[ "$GWMS_SINGULARITY_IMAGE" != *://* && ! -e "$GWMS_SINGULARITY_IMAGE" ]]; then
+        msg="\
+ERROR   Unable to access the Singularity image: $GWMS_SINGULARITY_IMAGE
+        Site and node: $OSG_SITE_NAME $(hostname -f)"
+        singularity_exit_or_fallback "$msg" 1 10m
+        return
+    fi
+
+    # Put a human readable version of the image in the env before expanding it - useful for monitoring
+    export GWMS_SINGULARITY_IMAGE_HUMAN="$GWMS_SINGULARITY_IMAGE"
+
+    # for /cvmfs based directory images, expand the path without symlinks so that
+    # the job can stay within the same image for the full duration
+    if cvmfs_path_in_cvmfs "$GWMS_SINGULARITY_IMAGE"; then
+        # Make sure CVMFS is mounted in Singularity
+        export GWMS_SINGULARITY_BIND_CVMFS=1
+        if (cd "$GWMS_SINGULARITY_IMAGE") >/dev/null 2>&1; then
+            # This will fail for images that are not expanded in CVMFS, just ignore the failure
+            local new_image_path
+            new_image_path=$( (cd "$GWMS_SINGULARITY_IMAGE" && pwd -P) 2>/dev/null )
+            if [[ -n "$new_image_path" ]]; then
+                GWMS_SINGULARITY_IMAGE=$new_image_path
+            fi
+        fi
+    fi
+
+    info_dbg "using image $GWMS_SINGULARITY_IMAGE_HUMAN ($GWMS_SINGULARITY_IMAGE)"
+    # Singularity image is OK, continue w/ other init
+
+    # set up the env to make sure Singularity uses the glidein dir for exported /tmp, /var/tmp
+    if [[ -n "$GLIDEIN_Tmp_Dir"  &&  -e "$GLIDEIN_Tmp_Dir" ]]; then
+        if mkdir "$GLIDEIN_Tmp_Dir/singularity-work.$$" ; then
+            export SINGULARITY_WORKDIR="$GLIDEIN_Tmp_Dir/singularity-work.$$"
+        else
+            warn "Unable to set SINGULARITY_WORKDIR to $GLIDEIN_Tmp_Dir/singularity-work.$$. Leaving it undefined."
+        fi
+    fi
+
+    GWMS_SINGULARITY_EXTRA_OPTS="$GLIDEIN_SINGULARITY_OPTS"
+
+    # Binding different mounts (they will be removed if not existent on the host)
+    # This is a dictionary in string w/ singularity mount options ("src1[:dst1[:opt1]][,src2[:dst2[:opt2]]]*"
+    # OSG: checks also in image, may not work if not expanded. And Singularity will not fail if missing, only give a warning
+    #  if [ -e $MNTPOINT/. -a -e $OSG_SINGULARITY_IMAGE/$MNTPOINT ]; then
+    GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS="/hadoop,/ceph,/hdfs,/lizard,/mnt/hadoop,/mnt/hdfs,/etc/hosts,/etc/localtime"
+
+    # CVMFS access inside container (default, but optional)
+    if [[ "x$GWMS_SINGULARITY_BIND_CVMFS" = "x1" ]]; then
+        GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS="`dict_set_val GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS /cvmfs`"
+    fi
+
+    # GPUs - bind outside OpenCL directory if available
+    if [[ -e /etc/OpenCL/vendors ]]; then
+        GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS="`dict_set_val GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS /etc/OpenCL/vendors /etc/OpenCL/vendors`"
+    fi
+    info_dbg "bind-path default (cvmfs:$GWMS_SINGULARITY_BIND_CVMFS, hostlib:`[ -n "$HOST_LIBS" ] && echo 1`, ocl:`[ -e /etc/OpenCL/vendors ] && echo 1`): $GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS"
+
+    # We want to bind $PWD to /srv within the container - however, in order
+    # to do that, we have to make sure everything we need is in $PWD, most
+    # notably $GWMS_DIR (bin, lib, ...), the user-job-wrapper.sh (this script!) 
+    # and singularity_lib.sh (in $GWMS_AUX_SUBDIR)
+    #
+    # If gwms dir is present, then copy it inside the container
+    [[ -z "$GWMS_SUBDIR" ]] && { GWMS_SUBDIR=".gwms.d"; warn "GWMS_SUBDIR was undefined, setting to '.gwms.d'"; }
+    local gwms_dir=${GWMS_DIR:-"../../$GWMS_SUBDIR"}
+    if [[ -d "$gwms_dir" ]]; then
+        if mkdir -p "$GWMS_SUBDIR" && cp -r "$gwms_dir"/* "$GWMS_SUBDIR/"; then
+            # Should copy only lib and bin instead?
+            # TODO: change the message when condor_chirp requires no more special treatment
+            info_dbg "copied GlideinWMS utilities (bin and libs, including condor_chirp) inside the container ($(pwd)/$GWMS_SUBDIR)"
+        else
+            warn "Unable to copy GlideinWMS utilities inside the container (to $(pwd)/$GWMS_SUBDIR)"
+        fi
+    else
+        warn "Unable to find GlideinWMS utilities ($gwms_dir from $(pwd))"
+    fi
+    # copy singularity_lib.sh (in $GWMS_AUX_SUBDIR)
+    mkdir -p "$GWMS_AUX_SUBDIR"
+    cp "${GWMS_AUX_DIR}/singularity_lib.sh" "$GWMS_AUX_SUBDIR/"       
+    # mount the original glidein directory (for setup scripts only, not jobs)
+    if [[ -n "$GWMS_BASE_SUBDIR" ]]; then
+        # Make the glidein directory visible in singularity
+        mkdir -p "$GWMS_BASE_SUBDIR"
+        GWMS_SINGULARITY_WRAPPER_BINDPATHS_OVERRIDE="${GWMS_SINGULARITY_WRAPPER_BINDPATHS_OVERRIDE:+${GWMS_SINGULARITY_WRAPPER_BINDPATHS_OVERRIDE},}$( dirname "${GWMS_THIS_SCRIPT_DIR}"):/srv/$GWMS_BASE_SUBDIR"
+    fi
+    # copy the wrapper.sh (this script!)
+    if [[ "$GWMS_THIS_SCRIPT" == */main/singularity_wrapper.sh ]]; then
+        export JOB_WRAPPER_SINGULARITY="/srv/$GWMS_BASE_SUBDIR/main/singularity_wrapper.sh"
+    else
+        cp "$GWMS_THIS_SCRIPT" .gwms-user-job-wrapper.sh
+        export JOB_WRAPPER_SINGULARITY="/srv/.gwms-user-job-wrapper.sh"
+    fi
+
+    # Get Singularity binds, uses also GLIDEIN_SINGULARITY_BINDPATH, GLIDEIN_SINGULARITY_BINDPATH_DEFAULT
+    # remove binds w/ non existing src (e)
+    local singularity_binds
+    singularity_binds=$(singularity_get_binds e "$GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS" "$GWMS_SINGULARITY_WRAPPER_BINDPATHS_OVERRIDE")
+    # Run and log the Singularity command.
+
+    echo "SingularityBind=\"$singularity_binds\""
+    echo "ContainerImage=\"$GWMS_SINGULARITY_IMAGE\""
+    if [ -f "$GWMS_SINGULARITY_IMAGE" ]; then
+        echo "WantSIF = true"
+    else
+        echo "WantSandboxImage = true"
+    fi
+    echo "SINGULARITY_JOB=true"
+    echo ""
+}
+
+
+# OSGVO - overrideing this from singularity_lib.sh
+singularity_get_image() {
+    # Return on stdout the Singularity image
+    # Let caller decide what to do if there are problems
+    # In:
+    #  1: a comma separated list of platforms (OS) to choose the image
+    #  2: a comma separated list of restrictions (default: none)
+    #     - cvmfs: image must be on CVMFS
+    #     - any: any image is OK, $1 was just a preference (the first one in SINGULARITY_IMAGES_DICT is used if none of the preferred is available)
+    #  SINGULARITY_IMAGES_DICT
+    #  SINGULARITY_IMAGE_DEFAULT (legacy)
+    #  SINGULARITY_IMAGE_DEFAULT6 (legacy)
+    #  SINGULARITY_IMAGE_DEFAULT7 (legacy)
+    # Out:
+    #  Singularity image path/URL returned on stdout
+    #  EC: 0: OK, 1: Empty/no image for the desired OS (or for any), 2: File not existing, 3: restriction not met (e.g. image not on cvmfs)
+
+    local s_platform="$1"
+    if [[ -z "$s_platform" ]]; then
+        warn "No desired platform, unable to select a Singularity image"
+        return 1
+    fi
+    local s_restrictions="$2"
+    local singularity_image
+
+    # To support legacy variables SINGULARITY_IMAGE_DEFAULT, SINGULARITY_IMAGE_DEFAULT6, SINGULARITY_IMAGE_DEFAULT7
+    # values are added to SINGULARITY_IMAGES_DICT
+    # TODO: These override existing dict values OK for legacy support (in the future we'll add && [ dict_check_key rhel6 ] to avoid this)
+    [[ -n "$SINGULARITY_IMAGE_DEFAULT6" ]] && SINGULARITY_IMAGES_DICT="`dict_set_val SINGULARITY_IMAGES_DICT rhel6 "$SINGULARITY_IMAGE_DEFAULT6"`"
+    [[ -n "$SINGULARITY_IMAGE_DEFAULT7" ]] && SINGULARITY_IMAGES_DICT="`dict_set_val SINGULARITY_IMAGES_DICT rhel7 "$SINGULARITY_IMAGE_DEFAULT7"`"
+    [[ -n "$SINGULARITY_IMAGE_DEFAULT" ]] && SINGULARITY_IMAGES_DICT="`dict_set_val SINGULARITY_IMAGES_DICT default "$SINGULARITY_IMAGE_DEFAULT"`"
+
+    # [ -n "$s_platform" ] not needed, s_platform is never null here (verified above)
+    # Try a match first, then check if there is "any" in the list
+    singularity_image="`dict_get_val SINGULARITY_IMAGES_DICT "$s_platform"`"
+    if [[ -z "$singularity_image" && ",${s_platform}," = *",any,"* ]]; then
+        # any means that any image is OK, take the 'default' one and if not there the   first one
+        singularity_image="`dict_get_val SINGULARITY_IMAGES_DICT default`"
+        [[ -z "$singularity_image" ]] && singularity_image="`dict_get_first SINGULARITY_IMAGES_DICT`"
+    fi
+
+    # At this point, GWMS_SINGULARITY_IMAGE is still empty, something is wrong
+    if [[ -z "$singularity_image" ]]; then
+        [[ -z "$SINGULARITY_IMAGES_DICT" ]] && warn "No Singularity image available (SINGULARITY_IMAGES_DICT is empty)" ||
+                warn "No Singularity image available for the required platforms ($s_platform)"
+        return 1
+    fi
+
+    singularity_image=$(download_or_build_singularity_image "$singularity_image") || return 1
+    info_dbg "bind-path default (cvmfs:$GWMS_SINGULARITY_BIND_CVMFS, hostlib:$([ -n "$HOST_LIBS" ] && echo 1), ocl:$([ -e /etc/OpenCL/vendors ] && echo 1)): $GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS"
+    info_dbg "Final image: $singularity_image"
+
+    echo "$singularity_image"
+}
+
+# Get things like GWMS_SINGULARITY_PATH from the glidein_config
+setup_from_environment
+
+info_dbg "Location of singularity: $GWMS_SINGULARITY_PATH"
+
+# Set up environment to know if HAS_SINGULARITY is enabled.
+setup_classad_variables
+GLIDEIN_DEBUG_OUTPUT=1
+
+# Check if singularity is disabled or enabled
+# This script could run when singularity is optional and not wanted
+# So should not fail but exec w/o running Singularity
+
+if [[ "x$HAS_SINGULARITY" != "x1"  ||  "x$GWMS_SINGULARITY_PATH" == "x" ]]; then
+    # No singularity needed; exit early.
+    info_dbg "Singularity is not supported - exiting early"
+    exit 0
+fi
+
+#############################################################################
+#
+# Will run w/ Singularity - prepare for it
+# From here on the script assumes it has to run w/ Singularity
+#
+info_dbg "Decided to use singularity ($HAS_SINGULARITY, $GWMS_SINGULARITY_PATH). Proceeding w/ tests and setup."
+
+# for mksquashfs
+PATH=$PATH:/usr/sbin
+
+# Should we use CVMFS or pull images directly?
+export ALLOW_NONCVMFS_IMAGES=$(get_prop_bool "$_CONDOR_MACHINE_AD" "ALLOW_NONCVMFS_IMAGES" 0)
+info_dbg "ALLOW_NONCVMFS_IMAGES: $ALLOW_NONCVMFS_IMAGES"
+
+# Should we use a sif file directly or unpack it first?
+# Rerun the test from osgvo-default-image and warn if the results don't match what's advertised.
+advertised_sif_support=$(get_prop_str "$_CONDOR_MACHINE_AD" "SINGULARITY_CAN_USE_SIF" 0)
+if [[ $advertised_sif_support == "HAS_SINGULARITY" ]]; then
+    advertised_sif_support=1
+fi
+
+UNPACK_SIF=1
+detected_sif_support=0
+if check_singularity_sif_support &>/dev/null; then
+    detected_sif_support=1
+    UNPACK_SIF=0
+fi
+if [[ $advertised_sif_support != $detected_sif_support ]]; then
+    info_dbg "SIF support: advertised SINGULARITY_CAN_USE_SIF ${advertised_sif_support} != detected ${detected_sif_support}; using detected."
+fi
+export UNPACK_SIF
+
+if [ "x$GWMS_SINGULARITY_IMAGE" != "x" ]; then
+    # intercept and maybe download the image
+    GWMS_SINGULARITY_IMAGE=$(download_or_build_singularity_image "$GWMS_SINGULARITY_IMAGE") || exit 1
+fi
+
+singularity_prepare_and_invoke "${@}"

--- a/node-check/itb-prepare-hook-lib
+++ b/node-check/itb-prepare-hook-lib
@@ -5,7 +5,7 @@
 # Used for the prepare job hook, particularly to select an appropriate Singularity image
 #
 GWMS_THIS_SCRIPT="$0"
-GWMS_THIS_SCRIPT_DIR=$(readlink -f $(dirname "$0")/..)
+GWMS_THIS_SCRIPT_DIR=$(readlink -f "$(dirname "$0")/..")
 EXITSLEEP=10m
 
 # Directory in Singularity where auxiliary files are copied (e.g. singularity_lib.sh)

--- a/node-check/itb-prepare-hook-lib
+++ b/node-check/itb-prepare-hook-lib
@@ -395,9 +395,15 @@ ERROR   Unable to access the Singularity image: $GWMS_SINGULARITY_IMAGE
 
     # Binding different mounts (they will be removed if not existent on the host)
     # This is a dictionary in string w/ singularity mount options ("src1[:dst1[:opt1]][,src2[:dst2[:opt2]]]*"
-    # OSG: checks also in image, may not work if not expanded. And Singularity will not fail if missing, only give a warning
-    #  if [ -e $MNTPOINT/. -a -e $OSG_SINGULARITY_IMAGE/$MNTPOINT ]; then
-    GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS="/hadoop,/ceph,/hdfs,/lizard,/mnt/hadoop,/mnt/hdfs,/etc/hosts,/etc/localtime"
+    # Binding different mounts (they will be removed if not existent on the host)
+    # This is a dictionary in string w/ singularity mount options ("src1[:dst1[:opt1]][,src2[:dst2[:opt2]]]*"
+    
+    GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS="/etc/hosts,/etc/localtime"
+    for MNTPOINT in /hadoop /ceph /hdfs /lizard /mnt/hadoop /mnt/hdfs; do
+        if [[ -d $MNTPOINT ]]; then
+            GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS="${GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS},${MNTPOINT}"
+        fi
+    done
 
     # CVMFS access inside container (default, but optional)
     if [[ "x$GWMS_SINGULARITY_BIND_CVMFS" = "x1" ]]; then

--- a/ospool.osg-htc.org/development/frontend-template.xml
+++ b/ospool.osg-htc.org/development/frontend-template.xml
@@ -142,6 +142,9 @@
             <file absfname="/opt/osg-flock/job-wrappers/itb-simple-job-wrapper.sh" after_entry="True" const="True" executable="False" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="True">
                <untar_options cond_attr="TRUE"/>
             </file>
+            <file absfname="/opt/osg-flock/node-check/itb-prepare-hook-lib" after_entry="False" const="True" executable="False" period="0" prefix="NOPREFIX" untar="False" wrapper="False">
+               <untar_options cond_attr="TRUE"/>
+            </file>
          </files>
       </group>
       <group name="itb-gpu" enabled="False">

--- a/ospool.osg-htc.org/development/frontend-template.xml
+++ b/ospool.osg-htc.org/development/frontend-template.xml
@@ -139,7 +139,7 @@
             <file absfname="/opt/osg-flock/node-check/itb-singularity-extras" after_entry="True" const="True" executable="True" period="0" prefix="NOPREFIX" untar="False" wrapper="False">
                <untar_options cond_attr="TRUE"/>
             </file>
-            <file absfname="/opt/osg-flock/job-wrappers/itb-default_singularity_wrapper.sh" after_entry="True" const="True" executable="False" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="True">
+            <file absfname="/opt/osg-flock/job-wrappers/itb-simple-job-wrapper.sh" after_entry="True" const="True" executable="False" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="True">
                <untar_options cond_attr="TRUE"/>
             </file>
          </files>


### PR DESCRIPTION
This reproduces the existing image selection logic for the OSPool into a standalone prepare job hook.  This will cause HTCondor to overwrite the ContainerImage attribute of the job to force GlideinWMS to use our specified image.

The goal here is twofold:

1.  Factor out the custom container selection logic, trying to get OSPool back to the stock GlideinWMS singularity execution.
2.  Set the relevant attributes so we could also use HTCondor-based Singularity execution.