### PR TITLE
ITB 667: use new script paths (canary)

### DIFF
--- a/ospool-pilot/itb-canary/job/prepare-hook
+++ b/ospool-pilot/itb-canary/job/prepare-hook
@@ -1,0 +1,1 @@
+../../itb/job/prepare-hook

--- a/ospool-pilot/itb-canary/job/simple-job-wrapper.sh
+++ b/ospool-pilot/itb-canary/job/simple-job-wrapper.sh
@@ -1,0 +1,1 @@
+../../itb/job/simple-job-wrapper.sh

--- a/ospool-pilot/itb-canary/lib/ospool-lib
+++ b/ospool-pilot/itb-canary/lib/ospool-lib
@@ -1,0 +1,1 @@
+../../itb/lib/ospool-lib

--- a/ospool-pilot/itb-canary/pilot/additional-htcondor-config
+++ b/ospool-pilot/itb-canary/pilot/additional-htcondor-config
@@ -1,0 +1,1 @@
+../../itb/pilot/additional-htcondor-config

--- a/ospool-pilot/itb-canary/pilot/advertise-base
+++ b/ospool-pilot/itb-canary/pilot/advertise-base
@@ -1,1 +1,578 @@
-../../itb/pilot/advertise-base
+#!/bin/bash
+#
+# This script probes a system for properties useful for OSGVO and
+# friends. This particular script runs "outside" Singularity.
+#
+# To be able to support both
+# integration with GlideinWMS and HTCondor startd cron, argv1 is used
+# to determine what mode we are in. If argv1 points to a glidein_config
+# file, GlideinWMS mode is assumed. If argv1 is "NONE", HTCondor startd
+# cron mode is assumed.
+#
+# More information:
+#    http://www.uscms.org/SoftwareComputing/Grid/WMS/glideinWMS/doc.prd/factory/custom_scripts.html
+#    http://research.cs.wisc.edu/htcondor/manual/v8.2/4_4Hooks.html
+#
+# Example HTCondor startd cron entry:
+#
+# STARTD_CRON_JOBLIST = $(STARTD_CRON_JOBLIST) osgvo
+# STARTD_CRON_osgvo_EXECUTABLE = /opt/osgvo/osgvo-node-advertise
+# STARTD_CRON_osgvo_PERIOD = 30m
+# STARTD_CRON_osgvo_MODE = periodic
+# STARTD_CRON_osgvo_RECONFIG = true
+# STARTD_CRON_osgvo_KILL = true
+# STARTD_CRON_osgvo_ARGS = NONE
+
+#######################################################################
+#
+# Configuration
+#
+
+# OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
+# This can be used by negotiators or users, for example to match
+# against a glidein newer than some base with new features.
+OSG_GLIDEIN_VERSION=666
+#######################################################################
+
+
+glidein_config="$1"
+
+function info {
+    echo "INFO  " $@ 1>&2
+}
+
+function my_warn {
+    echo "WARN  " $@ 1>&2
+    export GLIDEIN_VALIDATION_WARNINGS="$@. $GLIDEIN_VALIDATION_WARNINGS"
+}
+
+function advertise {
+    # atype is the type of the value as defined by GlideinWMS:
+    #   I - integer
+    #   S - quoted string
+    #   C - unquoted string (i.e. Condor keyword or expression)
+    key="$1"
+    value="$2"
+    atype="$3"
+
+    if [ "$glidein_config" != "NONE" ]; then
+        add_config_line_safe $key "$value"
+        add_condor_vars_line $key "$atype" "-" "+" "Y" "Y" "-"
+    fi
+
+    if [ "$atype" = "S" ]; then
+        echo "$key = \"$value\""
+    else
+        echo "$key = $value"
+    fi
+}
+
+function get_glidein_config_value {
+    # extracts a config attribute value from 
+    # $1 is the attribute key
+    CF=$glidein_config
+    if [ "$glidein_config" = "NONE" ]; then
+        CF="$PWD/glidein_config"
+    fi
+    KEY="$1"
+    VALUE=`(cat $CF | grep "^$KEY " | tail -n 1 | sed "s/^$KEY //") 2>/dev/null`
+    echo "$VALUE"
+}
+
+
+
+###########################################################
+# Ensure only one copy of this script is running at the 
+# same time. For example, if a mount or something hangs
+# further down, we do not want more copies of this script
+# to add to the problem.
+
+export PID_FILE=osgvo-node-advertise.pid
+if [ -e $PID_FILE ]; then
+    OLD_PID=`cat $PID_FILE 2>/dev/null`
+    if kill -0 $OLD_PID >/dev/null 2>&1; then
+        exit 0
+    fi
+fi
+echo $$ >$PID_FILE
+
+#############################################################################
+# At least glideinWMS 3.7.5 depends on the existence of a file named
+# log/StarterLog.  However, starting in 8.9.13, this log file no longer is
+# created by HTCondor.  To fix the statistics reporting, we simply create it
+# here.
+mkdir -p log execute
+touch log/StarterLog
+
+###########################################################
+# We have two env variables which can be added to in this
+# script to provide an expression for the START expression
+# and a general warnings string which gets published in the
+# ad. These are env variables until the end.
+
+export GLIDEIN_VALIDATION_EXPR="True"
+export GLIDEIN_VALIDATION_WARNINGS=""
+
+#############################################################################
+#
+# Some tests are too heavy-weight to run every
+# 5 minutes. Such test can drop a file named $TEST_FILE_1H.NNNNNNN
+# in cwd. These files will be cleaned up after 60 minutes and allow the
+# test to rerun then again. There is also a 3 hour version.
+#
+
+TEST_FILE_1H=osgvo.test-results.1h
+TEST_FILE_4H=osgvo.test-results.4h
+
+# clean up old ones
+find . -maxdepth 1 -name $TEST_FILE_1H.\* -mmin +60 -exec rm {} \;
+find . -maxdepth 1 -name $TEST_FILE_4H.\* -mmin +240 -exec rm {} \;
+find . -maxdepth 1 -name adv-singularity-work.\* -mmin +240 -exec rm -rf {} \;
+
+info "This is a setup script for the OSPool frontend."
+info "In case of problems, contact Mats Rynge (rynge@isi.edu)"
+info "Running in directory $PWD"
+    
+if [ -e glidein_config ]; then
+    # gwms 
+    info "GWMS directory detected. Staying in $PWD"
+elif [ -e ../glidein_config ]; then
+    # gwms stupid tmp dir for periodic scripts - this breaks
+    # out ability to cache results
+    cd ../
+    info "GWMS tmp directory detected. Switched directory to $PWD"
+elif [ "x$LOCAL_DIR" != "x" ]; then
+    # osgvo-docker-pilot - use specified dir
+    cd $LOCAL_DIR
+    info "osgvo-docker-pilot \$LOCAL_DIR directory detected. Switched directory to $PWD"
+else
+    # find a good directory for our tests - we need something that we
+    # can re-enter later to pick up cached results
+    for DER in $GLIDEIN_Tmp_Dir $TMP $TMPDIR /tmp . ; do
+        # do we have write permissions
+        if touch $DER/.writetest.$$ >/dev/null 2>&1; then
+            rm -f $DER/.writetest.$$
+            if mkdir -p $DER/osgvo-node-advertise.work >/dev/null 2>&1; then
+                cp $0 $DER/osgvo-node-advertise.work/
+                if [ -e add_config_line.source ]; then
+                    cp add_config_line.source $DER/osgvo-node-advertise.work/
+                fi
+                cd $DER/osgvo-node-advertise.work
+                info "Switched working directory to $PWD"
+                break
+            fi
+        fi
+    done
+fi
+
+# bash can set a default PATH - make sure it is exported
+export PATH=$PATH
+
+# some sites do not have PATH set
+if [ "x$PATH" = "x" ]; then
+    export PATH="/usr/local/bin:/usr/bin:/bin"
+    my_warn "PATH is empty, setting it to $PATH"
+fi
+info "PATH is set to $PATH"
+
+# CVMFS_BASE defaults to /cvmfs but can be overridden in case of for example cvmfsexec
+if [ "x$CVMFS_BASE" = "x" ]; then
+    CVMFS_BASE="/cvmfs"
+fi
+
+if [ "x$glidein_config" = "x" ]; then
+    glidein_config="NONE"
+    info "No arguments provided - assuming HTCondor startd cron mode"
+else
+    info "Arguments to the script: $*"
+    if [ -e "$glidein_config.saved" ]; then
+        info "$glidein_config.saved found; not doing any more writes"
+        glidein_config="NONE"
+    fi
+fi
+
+if [ "$glidein_config" != "NONE" ]; then
+    ###########################################################
+    # import advertise and add_condor_vars_line functions
+    if [ "x$add_config_line_source" = "x" ]; then
+        export add_config_line_source=`grep '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}'`
+        export condor_vars_file=`grep -i "^CONDOR_VARS_FILE " $glidein_config | awk '{print $2}'`
+    fi
+
+    # full path is problematic as sometimes we are inside a container - however, looks like
+    # the file is always named "add_config_line.source", so use that
+    add_config_line_source=$PWD/add_config_line.source
+
+    info "Sourcing $add_config_line_source"
+    source $add_config_line_source
+
+    # XXX Patch over add_config_line() with a safer version
+    # This will be fixed in gWMS 3.9.6
+    add_config_line() {
+        # Ignore the call if the exact config line is already in there
+        if ! grep -q "^${*}$" "${glidein_config}"; then
+            # Use temporary files to make sure multiple add_config_line() calls don't clobber
+            # the glidein_config.
+            local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
+            local tmp_config1="${glidein_config}.$r.1"
+            local tmp_config2="${glidein_config}.$r.2"
+
+            # Copy the glidein config so it doesn't get modified while we grep out the old value
+            if ! cp -p "${glidein_config}" "${tmp_config1}"; then
+                warn "Error writing ${tmp_config1}"
+                rm -f "${tmp_config1}"
+                exit 1
+            fi
+            grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
+            rm -f "${tmp_config1}"
+            if [ ! -f "${tmp_config2}" ]; then
+                warn "Error creating ${tmp_config2}"
+                exit 1
+            fi
+            # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
+            echo "$@" >> "${tmp_config2}"
+
+            # Replace glidein config atomically
+            if ! mv -f "${tmp_config2}" "${glidein_config}"; then
+                warn "Error updating ${glidein_config} from ${tmp_config2}"
+                rm -f "${tmp_config2}"
+                exit 1
+            fi
+        fi
+    }
+    # XXX End add_config_line() patch
+fi
+
+# timeout, if available, is used across many tests
+TIMEOUT=$(which timeout 2>/dev/null)
+if [ "x$TIMEOUT" != "x" ]; then
+    TIMEOUT="$TIMEOUT 30s"
+fi
+
+advertise OSG_GLIDEIN_VERSION $OSG_GLIDEIN_VERSION "I"
+
+# we need the "outside" kernel version to be able to steer
+# singularity jobs to kernel/glibcs which are not too old
+VER=`uname -r | sed 's/-.*//'`
+MAJ=`echo $VER | sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+)/\1/'`
+MIN=`echo $VER | sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+)/\2/'`
+PATCH=`echo $VER | sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+)/\3/'`
+VER=$(( 10000 * $MAJ + 100 * $MIN + $PATCH ))
+if [ "x$VER" != "x" ]; then
+    if [ $VER -gt 10000 ]; then
+        advertise OSG_HOST_KERNEL_VERSION "$VER" "I"
+    fi
+fi
+
+# verify http_proxy/OSG_SQUID_LOCATION
+PROXY_CHECKS=0
+PROXY_LOCATION=""
+if [ -e $TEST_FILE_4H.http_proxy.checks ]; then
+    PROXY_CHECKS=$(cat $TEST_FILE_4H.http_proxy.checks)
+    PROXY_LOCATION=$(cat $TEST_FILE_4H.http_proxy.location)
+else
+    CURL=$(curl --version 2>/dev/null)
+    for PROXY_CANDIDATE in $http_proxy $OSG_SQUID_LOCATION; do
+        PROXY_CHECKS=$(($PROXY_CHECKS + 1))
+        if [ "x$CURL" != "x" ]; then
+            env http_proxy=$PROXY_CANDIDATE curl -s -m 10 -o /dev/null http://cm-1.ospool.osg-htc.org/overview/
+        else
+            env http_proxy=$PROXY_CANDIDATE wget -q --timeout 10 -O /dev/null http://cm-1.ospool.osg-htc.org/overview/
+        fi
+        if [ $? = 0 ]; then
+            PROXY_LOCATION="$PROXY_CANDIDATE"
+            break
+        fi
+    done
+    echo $PROXY_CHECKS >$TEST_FILE_4H.http_proxy.checks
+    echo $PROXY_LOCATION >$TEST_FILE_4H.http_proxy.location
+fi
+
+if [ "x$PROXY_LOCATION" = "x" -a $PROXY_CHECKS -gt 0 ]; then
+    # checks peformed, but failed - limit what file transfers we can do
+    advertise HasFileTransferPluginMethods "data,ftp,file" "S"
+fi
+if [ "x$PROXY_LOCATION" != "x" ]; then
+    advertise "http_proxy" "$PROXY_LOCATION" "S"
+fi
+
+# some images require unsquashfs
+HAS_unsquashfs="False"
+if unsquashfs -v >/dev/null 2>&1; then
+    HAS_unsquashfs="True"
+fi
+# singularity also looks in places which may not be in user PATH
+if [ -e /usr/sbin/unsquashfs ]; then
+    HAS_unsquashfs="True"
+fi
+advertise HAS_unsquashfs "$HAS_unsquashfs" "C"
+
+# check for locally cached .sif images - this will be helpful when determining 
+# we want to disable Singularity if CVMFS is not available
+GWMS_SINGULARITY_CACHED_IMAGES=$( (cd images/ && ls *.sif | sort | paste -d, -s) 2>/dev/null)
+if [[ "x$GWMS_SINGULARITY_CACHED_IMAGES" != "x" ]]; then
+    advertise GWMS_SINGULARITY_CACHED_IMAGES "$GWMS_SINGULARITY_CACHED_IMAGES" "S"
+fi
+
+
+function disk_is_full {
+    local dir_to_check="$1"
+    local required_space_gb="$2"
+    # some sites have tiny envs which could affect this test
+    # for example, undefined $HOME
+    if [ -z "$dir_to_check" ]; then
+        return 1
+    fi
+    # also ignore directories which do not exist
+    if [ ! -e "$dir_to_check" ]; then
+        return 1
+    fi
+    (( disk_free=$(df -kP "$dir_to_check" 2>/dev/null | awk '{if (NR==2) print $4}') ))
+    [[ $(( disk_free / 1024 / 1024 )) -lt $required_space_gb ]]
+}
+
+# check space in SINGULARITY_CACHEDIR and SINGULARITY_TMPDIR
+#
+cachedir_required_space_gb=5
+tmpdir_required_space_gb=5
+
+# ~/.singularity/cache might not have been created yet; if so, check its parents for disk space
+cachedir_to_check=${SINGULARITY_CACHEDIR:-$HOME/.singularity/cache}
+[[ -e $cachedir_to_check ]] || cachedir_to_check=$HOME/.singularity
+[[ -e $cachedir_to_check ]] || cachedir_to_check=$HOME
+tmpdir_to_check=${SINGULARITY_TMPDIR:-${TMPDIR:-/tmp}}
+
+if disk_is_full "$cachedir_to_check" "$cachedir_required_space_gb" || \
+    disk_is_full "$tmpdir_to_check" "$tmpdir_required_space_gb"
+then
+    advertise SINGULARITY_DISK_IS_FULL "True" C
+else
+    advertise SINGULARITY_DISK_IS_FULL "False" C
+fi
+
+
+##################
+# cvmfs filesystem availability
+GLIDEIN_Entry_Name=$(get_glidein_config_value GLIDEIN_Entry_Name)
+info "Checking for CVMFS availability and attributes..."
+for FS in \
+   ams.cern.ch \
+   atlas.cern.ch \
+   belle.cern.ch \
+   clicdp.cern.ch \
+   cms.cern.ch \
+   connect.opensciencegrid.org \
+   desdm.osgstorage.org \
+   eic.opensciencegrid.org \
+   gluex.osgstorage.org \
+   gwosc.osgstorage.org \
+   icecube.opensciencegrid.org \
+   icecube.osgstorage.org \
+   larsoft-ib.opensciencegrid.org \
+   larsoft.opensciencegrid.org \
+   nexo.opensciencegrid.org \
+   oasis.opensciencegrid.org \
+   sft.cern.ch \
+   singularity.opensciencegrid.org \
+   snoplus.egi.eu \
+   sphenix.opensciencegrid.org \
+   spt.opensciencegrid.org \
+   stash.osgstorage.org \
+   sw.lsst.eu \
+   unpacked.cern.ch \
+   veritas.opensciencegrid.org \
+   xenon.opensciencegrid.org \
+; do
+    FS_CONV=`echo "$FS" | sed 's/[\.-]/_/g'`
+    FS_ATTR="HAS_CVMFS_$FS_CONV"
+    RESULT="False"
+    
+    # keep the filesystems mounted
+    ls -l "$CVMFS_BASE"/$FS/ >/dev/null 2>&1
+
+    if [ -e $TEST_FILE_4H.cvmfs-disabled.$FS ]; then
+        advertise $FS_ATTR "False" "C"
+        if [ "x$FS" = "xsingularity.opensciencegrid.org" -a "x$GWMS_SINGULARITY_CACHED_IMAGES" = "x" ]; then
+            advertise HAS_SINGULARITY "False" "C"
+            advertise SINGULARITY_COMMENT "Disabled due to CVMFS availability/errors" "S"
+        fi
+        continue
+    fi
+
+    if [ -e $CVMFS_BASE/$FS/. ]; then
+        RESULT="True"
+
+        # add the revision 
+        REV_ATTR="CVMFS_${FS_CONV}_REVISION"
+        REV_VAL=`/usr/bin/attr -q -g revision "$CVMFS_BASE"/$FS/. 2>/dev/null`
+        # some site mount /cvmfs over NFS and attr will not work
+        if [ "x$REV_VAL" = "x" ]; then
+            REV_VAL=0
+        fi
+
+        # add the error count
+        NIOERR_ATTR="CVMFS_${FS_CONV}_NIOERR"
+        NIOERR_VAL=`/usr/bin/attr -q -g nioerr "$CVMFS_BASE"/$FS/. 2>/dev/null`
+        # some site mount /cvmfs over NFS and attr will not work
+        if [ "x$NIOERR_VAL" = "x" ]; then
+            NIOERR_VAL=-1
+        fi
+        
+        # disable if the mount has had errors
+        if [ $NIOERR_VAL -gt 0 ]; then
+            RESULT="False"
+        fi
+       
+        # UUTAH is special case - broken NFS
+        if (echo "$GLIDEIN_Entry_Name" | egrep -i "UUTAH") >/dev/null 2>&1; then
+            RESULT="False"
+        fi
+        
+        # oasis.opensciencegrid.org needs extra checks
+        if [ "x$FS" = "xoasis.opensciencegrid.org" ]; then
+            if ! cat "$CVMFS_BASE"/oasis.opensciencegrid.org/osg/sw/module-init.sh >/dev/null 2>&1; then
+                RESULT="False"
+            fi
+            if ! cat "$CVMFS_BASE"/oasis.opensciencegrid.org/sbgrid/update.details >/dev/null 2>&1; then
+                RESULT="False"
+            fi
+        fi
+
+        # stash.osgstorage.org needs extra checks
+        if [ "x$FS" = "xstash.osgstorage.org" ]; then
+            if ! cat "$CVMFS_BASE"/stash.osgstorage.org/osgconnect/public/rynge/glidein-checks/testfile >/dev/null 2>&1; then
+                RESULT="False"
+            fi
+        fi
+        
+        # veritas.opensciencegrid.org
+        if [ "x$FS" = "xveritas.opensciencegrid.org" ]; then
+            if ! cat "$CVMFS_BASE"/veritas.opensciencegrid.org/py2-v1/setup.sh >/dev/null 2>&1; then
+                RESULT="False"
+            fi
+        fi
+        
+        # disable singularity if the singularity cvmfs has errors
+        if [ "x$FS" = "xsingularity.opensciencegrid.org" -a "x$GWMS_SINGULARITY_CACHED_IMAGES" = "x" ]; then
+            if [ $RESULT = "False" ]; then
+                advertise HAS_SINGULARITY "False" "C"
+                advertise SINGULARITY_COMMENT "Disabled due to CVMFS availability/errors" "S"
+            fi
+        fi
+
+        # now we are ready to advertise
+        advertise $FS_ATTR "$RESULT" "C"
+        advertise $REV_ATTR "$REV_VAL" "I"
+        advertise $NIOERR_ATTR "$NIOERR_VAL" "I"
+
+        # remember failures - we want do not want to run on cvmfs if it comes and goes...
+        if [ $RESULT = "False" ]; then
+            touch $TEST_FILE_4H.cvmfs-disabled.$FS
+        fi
+    else
+        # $FS is not available
+        advertise $FS_ATTR "False" "C"
+        # remember failures - we want do not want to run on cvmfs if it comes and goes...
+        if [ $RESULT = "False" ]; then
+            touch $TEST_FILE_4H.cvmfs-disabled.$FS
+        fi
+    fi
+
+done
+
+# update timestamp?
+TS_ATTR="CVMFS_oasis_opensciencegrid_org_TIMESTAMP"
+TS_VAL=`(cat "$CVMFS_BASE"/oasis.opensciencegrid.org/osg/update.details  | egrep '^Update unix time:' | sed 's/.*: //') 2>/dev/null`
+if [ "x$TS_VAL" != "x" ]; then
+    # make sure it is an integer
+    if [ "$TS_VAL" -eq "$TS_VAL" ] 2>/dev/null; then
+        advertise $TS_ATTR "$TS_VAL" "I"
+    fi
+fi
+
+###########################################################
+# system attributes from the host
+
+VIRTUALIZATION=`(systemd-detect-virt) 2>/dev/null`
+if [ "x$VIRTUALIZATION" != "x" ]; then
+    advertise VIRTUALIZATION_TECHNOLOGY "$VIRTUALIZATION" "S"
+fi
+
+SHM_AVAILABLE=`(df /dev/shm --output=size --block-size=1k | tail -n 1) 2>/dev/null`
+if [ "x$SHM_AVAILABLE" != "x" ]; then
+    advertise SHM_AVAILABLE "$SHM_AVAILABLE" "I"
+fi
+
+
+##################
+# stashcp
+
+# this is a one-shot test
+rm -f stashcp-test.file
+STASHCP_VERIFIED="False"
+if [ -e $TEST_FILE_1H.stashcp ]; then
+    STASHCP_VERIFIED=`cat $TEST_FILE_1H.stashcp`
+elif ($TIMEOUT ./client/stashcp /osgconnect/public/dweitzel/stashcp/test.file stashcp-test.file) >/dev/null 2>&1; then
+    STASHCP_VERIFIED="True"
+    echo "True" > $TEST_FILE_1H.stashcp
+else
+    echo "False" > $TEST_FILE_1H.stashcp
+fi
+rm -f testfile
+advertise STASHCP_VERIFIED "$STASHCP_VERIFIED" "C"
+
+# also record the version
+if [ -e ./client/stashcp ]; then
+    if [ ! -e $TEST_FILE_1H.stashcp-version ]; then
+        ./client/stashcp --version | grep '^Version:' | sed 's/.*: //' >$TEST_FILE_1H.stashcp-version
+    fi
+    VER=$(cat $TEST_FILE_1H.stashcp-version)
+    advertise STASHCP_VERSION "$VER" "S"
+fi
+
+if [ -z "$STASH_PLUGIN_PATH" ]; then
+    STASH_PLUGIN_PATH=$PWD/client/stash_plugin
+fi
+
+# also record the plugin version
+if [ -e "$STASH_PLUGIN_PATH" ]; then
+    if [ ! -e $TEST_FILE_1H.stash-plugin-version ]; then
+        "$STASH_PLUGIN_PATH" -classad | awk '/^PluginVersion / { print $3 }' | sed 's/"//g' >$TEST_FILE_1H.stash-plugin-version
+    fi
+    VER=$(cat $TEST_FILE_1H.stash-plugin-version)
+    advertise STASH_PLUGIN_VERSION "$VER" "S"
+fi
+
+###########################################################
+# Project restriction
+if [[ -n $OSG_PROJECT_NAME ]]; then
+    info "OSG_PROJECT_NAME=$OSG_PROJECT_NAME"
+    advertise OSG_PROJECT_NAME "$OSG_PROJECT_NAME" "S"
+    advertise OSG_PROJECT_RESTRICTION "ProjectName =?= OSG_PROJECT_NAME" "C"
+else
+    info "OSG_PROJECT_NAME is unset"
+fi
+
+##################
+# mostly done - update START validation expressions and warnings attribute
+if [ -e stop-glidein.stamp -o -e ../stop-glidein.stamp ]; then
+    advertise OSG_NODE_VALIDATED "False" "C"
+    advertise OSG_NODE_WARNINGS "Node is shutting down due to stop-glidein file" "S"
+else
+    advertise OSG_NODE_VALIDATED "$GLIDEIN_VALIDATION_EXPR" "C"
+    if [ "x$GLIDEIN_VALIDATION_WARNINGS" != "x" ]; then
+        advertise OSG_NODE_WARNINGS "$GLIDEIN_VALIDATION_WARNINGS" "S"
+    fi
+fi
+
+##################
+
+# Save a backup copy of glidein_config that won't get clobbered by startd_crons; also use this as a sentinel
+# so subsequent runs of this script won't modify glidein_config if it exists.
+if [[ $glidein_config != "NONE" && ! -e "$glidein_config.saved" ]]; then
+    cp -p "$glidein_config" "$glidein_config.saved"
+fi
+
+rm -f $PID_FILE
+info "All done - time to do some real work!"
+

--- a/ospool-pilot/itb-canary/pilot/advertise-base
+++ b/ospool-pilot/itb-canary/pilot/advertise-base
@@ -1,0 +1,1 @@
+../../itb/pilot/advertise-base

--- a/ospool-pilot/itb-canary/pilot/advertise-base
+++ b/ospool-pilot/itb-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=666
+OSG_GLIDEIN_VERSION=667
 #######################################################################
 
 

--- a/ospool-pilot/itb-canary/pilot/advertise-userenv
+++ b/ospool-pilot/itb-canary/pilot/advertise-userenv
@@ -1,0 +1,1 @@
+../../itb/pilot/advertise-userenv

--- a/ospool-pilot/itb-canary/pilot/default-image
+++ b/ospool-pilot/itb-canary/pilot/default-image
@@ -1,0 +1,1 @@
+../../itb/pilot/default-image

--- a/ospool-pilot/itb-canary/pilot/singularity-extras
+++ b/ospool-pilot/itb-canary/pilot/singularity-extras
@@ -1,0 +1,1 @@
+../../itb/pilot/singularity-extras

--- a/ospool-pilot/itb/pilot/additional-htcondor-config
+++ b/ospool-pilot/itb/pilot/additional-htcondor-config
@@ -266,7 +266,11 @@ set_unexported_condor_config_attribute "SINGULARITY_EXTRA_ARGUMENTS" '"--home $_
 # the Singularity container outside of the glidein default
 # image.
 glidein_group_dir=`grep -i "^GLIDECLIENT_GROUP_WORK_DIR " $glidein_config | awk '{print $2}'`
-hook_path=$glidein_group_dir/itb-prepare-hook-lib
+if [[ -e $glidein_group_dir/prepare-hook ]]; then
+    hook_path=$glidein_group_dir/prepare-hook
+else
+    hook_path=$glidein_group_dir/itb-prepare-hook-lib
+fi
 chmod +x "$hook_path"
 # TODO: these can all be replaced with set_unexported_condor_config_attribute
 add_config_line "OSPOOL_HOOK_PREPARE_JOB" "$hook_path"

--- a/ospool.osg-htc.org/development/frontend-template.xml
+++ b/ospool.osg-htc.org/development/frontend-template.xml
@@ -205,28 +205,28 @@
             <attr name="OSG_DEFAULT_CONTAINER_DISTRIBUTION_GPU" glidein_publish="False" job_publish="False" parameter="True" type="string" value="100%__opensciencegrid/osgvo-el7-cuda10:latest"/>
          </attrs>
          <files>
-            <file absfname="/opt/osg-flock/node-check/itb-ospool-lib" after_entry="False" const="True" executable="True" period="0" prefix="NOPREFIX" untar="False" wrapper="False">
+            <file absfname="/opt/osg-flock/ospool-pilot/itb-canary/lib/ospool-lib" after_entry="False" const="True" executable="True" period="0" prefix="NOPREFIX" untar="False" wrapper="False">
                <untar_options cond_attr="TRUE"/>
             </file>
-            <file absfname="/opt/osg-flock/node-check/itb-osgvo-advertise-base" after_entry="True" const="True" executable="True" period="180" prefix="NOPREFIX" untar="False" wrapper="False">
+            <file absfname="/opt/osg-flock/ospool-pilot/itb-canary/pilot/advertise-base" after_entry="True" const="True" executable="True" period="180" prefix="NOPREFIX" untar="False" wrapper="False">
                <untar_options cond_attr="TRUE"/>
             </file>
-            <file absfname="/opt/osg-flock/node-check/itb-osgvo-advertise-userenv" type="run:singularity" after_entry="True" const="True" executable="True" prefix="NOPREFIX" untar="False" wrapper="False">
+            <file absfname="/opt/osg-flock/ospool-pilot/itb-canary/pilot/advertise-userenv" type="run:singularity" after_entry="True" const="True" executable="True" prefix="NOPREFIX" untar="False" wrapper="False">
                <untar_options cond_attr="TRUE"/>
             </file>
-            <file absfname="/opt/osg-flock/node-check/itb-osgvo-default-image" after_entry="False" const="True" executable="True" period="0" prefix="NOPREFIX" untar="False" wrapper="False">
+            <file absfname="/opt/osg-flock/ospool-pilot/itb-canary/pilot/default-image" after_entry="False" const="True" executable="True" period="0" prefix="NOPREFIX" untar="False" wrapper="False">
                <untar_options cond_attr="TRUE"/>
             </file>
-            <file absfname="/opt/osg-flock/node-check/itb-singularity-extras" after_entry="True" const="True" executable="True" period="0" prefix="NOPREFIX" untar="False" wrapper="False">
+            <file absfname="/opt/osg-flock/ospool-pilot/itb-canary/pilot/singularity-extras" after_entry="True" const="True" executable="True" period="0" prefix="NOPREFIX" untar="False" wrapper="False">
                <untar_options cond_attr="TRUE"/>
             </file>
-            <file absfname="/opt/osg-flock/node-check/itb-osgvo-additional-htcondor-config" after_entry="True" after_group="False" const="True" executable="True" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="False">
+            <file absfname="/opt/osg-flock/ospool-pilot/itb-canary/pilot/additional-htcondor-config" after_entry="True" after_group="False" const="True" executable="True" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="False">
                <untar_options cond_attr="TRUE"/>
             </file>
-            <file absfname="/opt/osg-flock/job-wrappers/itb-simple-job-wrapper.sh" after_entry="True" const="True" executable="False" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="True">
+            <file absfname="/opt/osg-flock/ospool-pilot/itb-canary/job/simple-job-wrapper.sh" after_entry="True" const="True" executable="False" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="True">
                <untar_options cond_attr="TRUE"/>
             </file>
-            <file absfname="/opt/osg-flock/node-check/itb-prepare-hook-lib" after_entry="False" const="True" executable="False" period="0" prefix="NOPREFIX" untar="False" wrapper="False">
+            <file absfname="/opt/osg-flock/ospool-pilot/itb-canary/job/prepare-hook" after_entry="False" const="True" executable="False" period="0" prefix="NOPREFIX" untar="False" wrapper="False">
                <untar_options cond_attr="TRUE"/>
             </file>
          </files>

--- a/ospool.osg-htc.org/development/frontend-template.xml
+++ b/ospool.osg-htc.org/development/frontend-template.xml
@@ -139,6 +139,9 @@
             <file absfname="/opt/osg-flock/node-check/itb-singularity-extras" after_entry="True" const="True" executable="True" period="0" prefix="NOPREFIX" untar="False" wrapper="False">
                <untar_options cond_attr="TRUE"/>
             </file>
+            <file absfname="/opt/osg-flock/node-check/itb-osgvo-additional-htcondor-config" after_entry="True" after_group="False" const="True" executable="True" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="False">
+               <untar_options cond_attr="TRUE"/>
+            </file>
             <file absfname="/opt/osg-flock/job-wrappers/itb-simple-job-wrapper.sh" after_entry="True" const="True" executable="False" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="True">
                <untar_options cond_attr="TRUE"/>
             </file>
@@ -215,6 +218,9 @@
                <untar_options cond_attr="TRUE"/>
             </file>
             <file absfname="/opt/osg-flock/node-check/itb-singularity-extras" after_entry="True" const="True" executable="True" period="0" prefix="NOPREFIX" untar="False" wrapper="False">
+               <untar_options cond_attr="TRUE"/>
+            </file>
+            <file absfname="/opt/osg-flock/node-check/itb-osgvo-additional-htcondor-config" after_entry="True" after_group="False" const="True" executable="True" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="False">
                <untar_options cond_attr="TRUE"/>
             </file>
             <file absfname="/opt/osg-flock/job-wrappers/itb-simple-job-wrapper.sh" after_entry="True" const="True" executable="False" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="True">
@@ -297,6 +303,9 @@
             <file absfname="/opt/osg-flock/node-check/itb-singularity-extras" after_entry="True" const="True" executable="True" period="0" prefix="NOPREFIX" untar="False" wrapper="False">
                <untar_options cond_attr="TRUE"/>
             </file>
+            <file absfname="/opt/osg-flock/node-check/itb-osgvo-additional-htcondor-config" after_entry="True" after_group="False" const="True" executable="True" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="False">
+               <untar_options cond_attr="TRUE"/>
+            </file>
             <file absfname="/opt/osg-flock/job-wrappers/itb-simple-job-wrapper.sh" after_entry="True" const="True" executable="False" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="True">
                <untar_options cond_attr="TRUE"/>
             </file>
@@ -335,9 +344,6 @@
          <untar_options cond_attr="TRUE"/>
       </file>
       <file absfname="/opt/osg-flock/stashcp/itb/stash_plugin" after_entry="False" after_group="False" const="True" executable="False" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="False">
-         <untar_options cond_attr="TRUE"/>
-      </file>
-      <file absfname="/opt/osg-flock/node-check/itb-osgvo-additional-htcondor-config" after_entry="True" after_group="False" const="True" executable="True" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="False">
          <untar_options cond_attr="TRUE"/>
       </file>
       <file absfname="/opt/osg-flock/node-check/scitokens" after_entry="True" after_group="False" const="True" executable="True" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="False">


### PR DESCRIPTION
This changes the `itb-canary` frontend group to use the new script locations for the node validation, job wrapper, and job prepare hook scripts. Some minor changes were needed to handle the renamed prepare-job hook. Only `advertise-base` is different between `itb` and `itb-canary` (for the version bump); otherwise the scripts are symlinks.