### PR TITLE
main 652: Fix getting $advertised_sif_support

### DIFF
--- a/ospool-pilot/main-canary/pilot/advertise-base
+++ b/ospool-pilot/main-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=651
+OSG_GLIDEIN_VERSION=652
 #######################################################################
 
 

--- a/ospool-pilot/main/job/default_singularity_wrapper.sh
+++ b/ospool-pilot/main/job/default_singularity_wrapper.sh
@@ -755,9 +755,11 @@ if [[ -z "$GWMS_SINGULARITY_REEXEC" ]]; then
 
         # Should we use a sif file directly or unpack it first?
         # Rerun the test from osgvo-default-image and warn if the results don't match what's advertised.
-        advertised_sif_support=$(get_prop_str "$_CONDOR_MACHINE_AD" "SINGULARITY_CAN_USE_SIF" 0)
-        if [[ $advertised_sif_support == "HAS_SINGULARITY" ]]; then
+        advertised_sif_support=$(get_prop_str "$_CONDOR_MACHINE_AD" "SINGULARITY_CAN_USE_SIF" "false" | tr A-Z a-z)
+        if [[ $advertised_sif_support != "false" ]]; then
             advertised_sif_support=1
+        else
+            advertised_sif_support=0
         fi
 
         UNPACK_SIF=1

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=651
+OSG_GLIDEIN_VERSION=652
 #######################################################################
 
 


### PR DESCRIPTION
Same as #195 for main and main-canary. (main-canary's default_singularity_wrapper.sh is a symlink to main's so aside from the version bump only one file needed changing.)