### PR TITLE
ITB 670: simplify SINGULARITY_START_CLAUSE

### DIFF
--- a/ospool-pilot/itb-canary/pilot/advertise-base
+++ b/ospool-pilot/itb-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=669
+OSG_GLIDEIN_VERSION=670
 #######################################################################
 
 

--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=669
+OSG_GLIDEIN_VERSION=670
 #######################################################################
 
 

--- a/ospool-pilot/itb/pilot/singularity-extras
+++ b/ospool-pilot/itb/pilot/singularity-extras
@@ -112,8 +112,8 @@ else
 fi
 
 
-clause1='(SINGULARITY_CAN_USE_REGISTRY || !(size(TARGET.SingularityImage) >= 9 && substr(TARGET.SingularityImage, 0, 9) == "docker://"))'
-clause2='(SINGULARITY_CAN_USE_SIF || !(size(TARGET.SingularityImage) >= 4 && substr(TARGET.SingularityImage, -4) == ".sif"))'
+clause1='(SINGULARITY_CAN_USE_REGISTRY || !(substr(TARGET.SingularityImage, 0, 9) == "docker://"))'
+clause2='(SINGULARITY_CAN_USE_SIF || !(substr(TARGET.SingularityImage, -4) == ".sif"))'
 advertise SINGULARITY_START_CLAUSE "(!isString(TARGET.SingularityImage) || ( $clause1 && $clause2 ))"  "C"
 
 # Tell HTCondor the path to the Singularity binary; this is a config option not an atribute


### PR DESCRIPTION
We no longer need to do a string size check before using `substr`; the condor crash caused by substr'ing a too-small string is fixed.