### PR TITLE
main-canary 654: Don't pollute the job environment with unnecessary vars

### DIFF
--- a/ospool-pilot/main-canary/pilot/additional-htcondor-config
+++ b/ospool-pilot/main-canary/pilot/additional-htcondor-config
@@ -195,6 +195,37 @@ else
     while read line; do warn "$line"; done < stashcp-test.log
 fi
 
+##################################################################
+# Generate a minimal `STARTER_JOB_ENVIRONMENT`, mostly composed of
+# informational variables that are considered safe to always leak to
+# the job environment.
+#
+# Source of OSG_* variables:
+#   https://github.com/opensciencegrid/osg-configure/blob/dcd02313500cf113e8a6c27571197b4803295774/scripts/osg-configure#L27
+# Removed the following ones that don't appear actively used anymore:
+#  OSG_GRID, OSG_APP, OSG_DATA, OSG_SITE_READ, OSG_SITE_WRITE
+# Removed $OSG_WN_TMP because any job should use the HTCondor-provided scratch dir.
+# Considered and not passed through:
+#   LANG
+info "Calculating default job environment variables."
+
+job_env=
+for envvar in \
+     OSG_SITE_NAME \
+     OSG_HOSTNAME \
+     OSG_SQUID_LOCATION \
+     http_proxy \
+     https_proxy \
+     FTP_PROXY \
+     X509_USER_PROXY \
+; do
+
+if [ ! -z ${!envvar+x} ]; then
+  add_config_line "${envvar}" "${!envvar}"
+  add_condor_vars_line "${envvar}" "C" "-" "${envvar}" "N" "N" "+"
+fi
+
+done
 ###########################################################
 
 echo "All done (osgvo-additional-htcondor-config)"

--- a/ospool-pilot/main-canary/pilot/advertise-base
+++ b/ospool-pilot/main-canary/pilot/advertise-base
@@ -57,7 +57,7 @@ function advertise {
 
     if [ "$glidein_config" != "NONE" ]; then
         add_config_line_safe $key "$value"
-        add_condor_vars_line $key "$atype" "-" "+" "Y" "Y" "+"
+        add_condor_vars_line $key "$atype" "-" "+" "Y" "Y" "-"
     fi
 
     if [ "$atype" = "S" ]; then
@@ -207,6 +207,7 @@ if [ "$glidein_config" != "NONE" ]; then
     source $add_config_line_source
 
     # XXX Patch over add_config_line() with a safer version
+    # This will be fixed in gWMS 3.9.6
     add_config_line() {
         # Ignore the call if the exact config line is already in there
         if ! grep -q "^${*}$" "${glidein_config}"; then

--- a/ospool-pilot/main-canary/pilot/advertise-base
+++ b/ospool-pilot/main-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=653
+OSG_GLIDEIN_VERSION=654
 #######################################################################
 
 

--- a/ospool-pilot/main-canary/pilot/advertise-userenv
+++ b/ospool-pilot/main-canary/pilot/advertise-userenv
@@ -53,7 +53,7 @@ function advertise {
 
     if [ "$glidein_config" != "NONE" ]; then
         add_config_line_safe $key "$value"
-        add_condor_vars_line $key "$atype" "-" "+" "Y" "Y" "+"
+        add_condor_vars_line $key "$atype" "-" "+" "Y" "Y" "-"
     fi
 
     if [ "$atype" = "S" ]; then


### PR DESCRIPTION
Do not put many the attributes we put in the machine ad into the environment by default; also generate a minimal STARTER_JOB_ENVIRONMENT consisting of a handful of variables that we consider OK to end up in the job's environment.

This change may have unknown consequences so try it out in main-canary first.