### PR TITLE
main, main-canary 657: Make stashcp and the stash plugin executable before checking their versions

### DIFF
--- a/ospool-pilot/main-canary/pilot/advertise-base
+++ b/ospool-pilot/main-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=656
+OSG_GLIDEIN_VERSION=657
 #######################################################################
 
 
@@ -509,6 +509,7 @@ fi
 
 # this is a one-shot test
 rm -f stashcp-test.file
+chmod +x ./client/stashcp
 STASHCP_VERIFIED="False"
 if [ -e $TEST_FILE_1H.stashcp ]; then
     STASHCP_VERIFIED=`cat $TEST_FILE_1H.stashcp`
@@ -536,6 +537,7 @@ fi
 
 # also record the plugin version
 if [ -e "$STASH_PLUGIN_PATH" ]; then
+    chmod +x "$STASH_PLUGIN_PATH"
     if [ ! -e $TEST_FILE_1H.stash-plugin-version ]; then
         "$STASH_PLUGIN_PATH" -classad | awk '/^PluginVersion / { print $3 }' | sed 's/"//g' >$TEST_FILE_1H.stash-plugin-version
     fi

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=656
+OSG_GLIDEIN_VERSION=657
 #######################################################################
 
 
@@ -509,6 +509,7 @@ fi
 
 # this is a one-shot test
 rm -f stashcp-test.file
+chmod +x ./client/stashcp
 STASHCP_VERIFIED="False"
 if [ -e $TEST_FILE_1H.stashcp ]; then
     STASHCP_VERIFIED=`cat $TEST_FILE_1H.stashcp`
@@ -536,6 +537,7 @@ fi
 
 # also record the plugin version
 if [ -e "$STASH_PLUGIN_PATH" ]; then
+    chmod +x "$STASH_PLUGIN_PATH"
     if [ ! -e $TEST_FILE_1H.stash-plugin-version ]; then
         "$STASH_PLUGIN_PATH" -classad | awk '/^PluginVersion / { print $3 }' | sed 's/"//g' >$TEST_FILE_1H.stash-plugin-version
     fi


### PR DESCRIPTION
To fix missing STASH_PLUGIN_VERSION attribute. "additional-htcondor-config" normally takes care of making stashcp and stash_plugin executable, but it's "advertise-base" that advertises STASH_PLUGIN_VERSION, so if advertise-base runs first, it won't be able to run stashcp and stash_plugin, and will consider it a test failure.