### PR TITLE
main, main-canary 658: add some non job-hook changes from ITB

### DIFF
--- a/ospool-pilot/main-canary/pilot/advertise-base
+++ b/ospool-pilot/main-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=657
+OSG_GLIDEIN_VERSION=658
 #######################################################################
 
 

--- a/ospool-pilot/main/lib/ospool-lib
+++ b/ospool-pilot/main/lib/ospool-lib
@@ -26,7 +26,7 @@ function advertise {
 
     if [ "$glidein_config" != "NONE" ]; then
         add_config_line_safe $key "$value"
-        add_condor_vars_line $key "$atype" "-" "+" "Y" "Y" "+"
+        add_condor_vars_line $key "$atype" "-" "+" "Y" "Y" "-"
     fi
 
     if [ "$atype" = "S" ]; then

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=657
+OSG_GLIDEIN_VERSION=658
 #######################################################################
 
 

--- a/ospool-pilot/main/pilot/default-image
+++ b/ospool-pilot/main/pilot/default-image
@@ -138,6 +138,7 @@ function determine_default_container_image {
             advertise GWMS_SINGULARITY_PULL_IMAGES "True" "C"
             advertise SINGULARITY_IMAGES_DICT "default:$IMAGE_PATH" "S"
             advertise REQUIRED_OS "default" "S"
+            advertise OSG_DEFAULT_SINGULARITY_IMAGE "$IMAGE_PATH" "S"
             return 0
         else
             my_warn "Failed to pull $SELECTED_IMAGE; falling back to CVMFS"
@@ -147,6 +148,7 @@ function determine_default_container_image {
     # prepend the base bath
     SELECTED_IMAGE="/cvmfs/singularity.opensciencegrid.org/$SELECTED_IMAGE"
     advertise SINGULARITY_IMAGES_DICT "default:$SELECTED_IMAGE" "S"
+    advertise OSG_DEFAULT_SINGULARITY_IMAGE "$SELECTED_IMAGE" "S"
     advertise REQUIRED_OS "default" "S"
 }
 

--- a/ospool-pilot/main/pilot/singularity-extras
+++ b/ospool-pilot/main/pilot/singularity-extras
@@ -106,22 +106,21 @@ if check_singularity_sif_support; then
     # make sure this goes false if we later figure out that
     # singularity is not working correctly
     advertise SINGULARITY_CAN_USE_SIF "HAS_SINGULARITY && STASHCP_VERIFIED" "C"
+    # can the provided Singularity run registry images?
+    # Pulling from docker:// URLs requires creating a SIF first which is done in the tempdir and is cached in the cachedir
+    if check_singularity_registry_support; then
+        advertise SINGULARITY_CAN_USE_REGISTRY "SINGULARITY_CAN_USE_SIF && SINGULARITY_DISK_IS_FULL =!= True" "C"
+    else
+        advertise SINGULARITY_CAN_USE_REGISTRY "False" "C"
+    fi
 else
     advertise SINGULARITY_CAN_USE_SIF "False" "C"
-fi
-
-# can the provided Singularity run registry images?
-if check_singularity_registry_support; then
-    # make sure this goes false if we later figure out that
-    # singularity is not working correctly
-    # Pulling from docker:// URLs requires creating a SIF first which is done in the tempdir and is cached in the cachedir
-    advertise SINGULARITY_CAN_USE_REGISTRY "SINGULARITY_CAN_USE_SIF && SINGULARITY_DISK_IS_FULL =!= True" "C"
-else
     advertise SINGULARITY_CAN_USE_REGISTRY "False" "C"
 fi
 
-clause1='(SINGULARITY_CAN_USE_REGISTRY || !(size(TARGET.SingularityImage) >= 9 && substr(TARGET.SingularityImage, 0, 9) == "docker://"))'
-clause2='(SINGULARITY_CAN_USE_SIF || !(size(TARGET.SingularityImage) >= 4 && substr(TARGET.SingularityImage, -4) == ".sif"))'
+
+clause1='(SINGULARITY_CAN_USE_REGISTRY || !(substr(TARGET.SingularityImage, 0, 9) == "docker://"))'
+clause2='(SINGULARITY_CAN_USE_SIF || !(substr(TARGET.SingularityImage, -4) == ".sif"))'
 advertise SINGULARITY_START_CLAUSE "(!isString(TARGET.SingularityImage) || ( $clause1 && $clause2 ))"  "C"
 
 # Tell HTCondor the path to the Singularity binary; this is a config option not an atribute


### PR DESCRIPTION
- ospool-lib: don't put advertised values into the job environment
- don't bother checking for singularity registry support if we can't use sif files
- simplify SINGULARITY_START_CLAUSE
- advertise OSG_DEFAULT_SINGULARITY_IMAGE