### PR TITLE
main-canary 684: use job hook for Singularity

### DIFF
--- a/ospool-pilot/main-canary/job/default_singularity_wrapper.sh
+++ b/ospool-pilot/main-canary/job/default_singularity_wrapper.sh
@@ -1,1 +1,0 @@
-../../main/job/default_singularity_wrapper.sh

--- a/ospool-pilot/main-canary/job/prepare-hook
+++ b/ospool-pilot/main-canary/job/prepare-hook
@@ -1,0 +1,459 @@
+#!/bin/bash
+#
+# OSPool / GlideinWMS helper functions.
+#
+# Used for the prepare job hook, particularly to select an appropriate Singularity image
+#
+GWMS_THIS_SCRIPT="$0"
+GWMS_THIS_SCRIPT_DIR=$(readlink -f "$(dirname "$0")/..")
+EXITSLEEP=10m
+
+# Directory in Singularity where auxiliary files are copied (e.g. singularity_lib.sh)
+GWMS_AUX_SUBDIR=${GWMS_AUX_SUBDIR:-".gwms_aux"}
+export GWMS_AUX_SUBDIR
+
+# GWMS_BASE_SUBDIR (directory where the base glidein directory is mounted) not defiled in Singularity for the user jobs, only for setup scripts
+# Directory to use for bin, lib, exec, ...
+GWMS_SUBDIR=${GWMS_SUBDIR:-".gwms.d"}
+export GWMS_SUBDIR
+
+# CVMFS_BASE defaults to /cvmfs but can be overridden in case of for example cvmfsexec
+if [ "x$CVMFS_BASE" = "x" ]; then
+    CVMFS_BASE="/cvmfs"
+fi
+
+# Manage GWMS debug and info messages in the stdout/err (unless userjob option is set)
+#[[ ! ",${GLIDEIN_DEBUG_OPTIONS}," = *,userjob,* ]] && GLIDEIN_QUIET=True
+[[ ! ",${GLIDEIN_DEBUG_OPTIONS}," = *,nowait,* ]] && EXITSLEEP=2m  # leave 2min to update classad
+GLIDEIN_DEBUG_OUTPUT=1
+
+# When failing we need to tell HTCondor to put the job back in the queue by creating
+# a file in the PATH pointed by $_CONDOR_WRAPPER_ERROR_FILE
+# Make sure there is no leftover wrapper error file (if the file exists HTCondor assumes the wrapper failed)
+[[ -n "$_CONDOR_WRAPPER_ERROR_FILE" ]] && rm -f "$_CONDOR_WRAPPER_ERROR_FILE" >/dev/null 2>&1 || true
+
+
+escape_str () {
+    # Escape backslashes and double-quotes in a one-line string
+    # (if the string is multiple lines, print only the first line)
+    local str="$1"
+    sed -n -e '1s/\\/\\\\/g' \
+           -e '1s/"/\\"/g' \
+           -e '1p' <<<"$str"
+}
+
+
+# HookStatusCode reference:
+# 000 : Success, continue with job launching
+# 001 - 299 : Failure, unspecified; puts job on hold
+# 300 - 399 : Failure due to a permanent error local to this EP
+# 400 - 499 : Failure due to a temporary error local to this EP
+# 500 - 599 : Failure due to a permanent error from a 3rd party site server attached to this EP
+# 600 - 699 : Failure due to a temporary error from a 3rd party site server attached to this EP
+
+exit_hook () {
+    # Print a HookStatusCode and HookStatusMessage and exit.
+    # 1: Number to use for HookStatusCode.
+    #    If HookStatusCode > 0, use 1-100 for the script's exit status based on the last 2 digits.
+    # 2: Message to use for HookStatusMessage.
+    # 3: Sleep time before exiting (0 by default)
+    local hook_status_code="$1"
+    local hook_status_message="$2"
+    local sleep_time="${3:-0}"
+
+    printf "HookStatusCode=%d\n" "$hook_status_code"
+    printf 'HookStatusMessage="%s"\n' "$(escape_str "$hook_status_message")"
+
+    local ret=0
+    if [[ $hook_status_code -gt 0 ]]; then
+        # also print code and error to stderr
+        printf "%03d\t%s\n" "$hook_status_code" "$hook_status_message" >&2
+        ret=$(( hook_status_code % 100 ))
+        if [[ $ret == 0 ]]; then
+            ret=100  # use 100 since exit 0 would imply success
+        fi
+    fi
+
+    sleep "$sleep_time"
+
+    exit $ret
+}
+
+
+exit_hook_stop_pilot () {
+    # Exit the hook and stop the pilot
+    # 1: HookStatusCode
+    # 2: HookStatusMessage
+    # 3: Sleep time ($EXITSLEEP by default)
+
+    # Signal other parts of the glidein that it is time to stop accepting jobs
+    touch $GWMS_THIS_SCRIPT_DIR/stop-glidein.stamp &>/dev/null
+
+    exit_hook "$1" "$2" "${3:-$EXITSLEEP}"
+}
+
+
+# In case singularity_lib cannot be imported
+warn_raw () {
+    echo "$@" 1>&2
+}
+
+
+error_msg () {
+    echo "ERROR: $GWMS_THIS_SCRIPT: $*" >&2
+}
+
+# Ensure all jobs have PATH set
+# bash can set a default PATH - make sure it is exported
+export PATH=$PATH
+[[ -z "$PATH" ]] && export PATH="/usr/local/bin:/usr/bin:/bin"
+
+[[ -z "$glidein_config" ]] && [[ -e "$GWMS_THIS_SCRIPT_DIR/glidein_config" ]] &&
+    export glidein_config="$GWMS_THIS_SCRIPT_DIR/glidein_config"
+
+# Source utility files, outside and inside Singularity
+# condor_job_wrapper is in the base directory, singularity_lib.sh in main
+# and copied to RUNDIR/$GWMS_AUX_SUBDIR (RUNDIR becomes /srv in Singularity)
+if [[ -e "$GWMS_THIS_SCRIPT_DIR/main/singularity_lib.sh" ]]; then
+    GWMS_AUX_DIR="$GWMS_THIS_SCRIPT_DIR/main"
+else
+    exit_hook_stop_pilot 301 "Unable to source singularity_lib.sh! File not found."
+fi
+# shellcheck source=../singularity_lib.sh
+. "${GWMS_AUX_DIR}"/singularity_lib.sh
+
+# Directory to use for bin, lib, exec, ... full path
+if [[ -n "$GWMS_DIR" && -e "$GWMS_DIR/bin" ]]; then
+    # already set, keep it
+    true
+elif [[ -e $GWMS_THIS_SCRIPT_DIR/$GWMS_SUBDIR/bin ]]; then
+    GWMS_DIR=$GWMS_THIS_SCRIPT_DIR/$GWMS_SUBDIR
+else
+    exit_hook_stop_pilot 302 "Unable to find GWMS_DIR! (GWMS_THIS_SCRIPT_DIR=$GWMS_THIS_SCRIPT_DIR GWMS_SUBDIR=$GWMS_SUBDIR)"
+fi
+export GWMS_DIR
+
+
+
+function get_glidein_config_value {
+    # extracts a config attribute value from
+    # $1 is the attribute key
+    CF=$glidein_config
+    if [ -e "$CF.saved" ]; then
+        CF=$CF.saved
+    fi
+    KEY="$1"
+    VALUE=`(cat $CF | grep "^$KEY " | tail -n 1 | sed "s/^$KEY //") 2>/dev/null`
+    echo "$VALUE"
+}
+
+
+# OS Pool helpers
+# source our helpers
+group_dir=$(get_glidein_config_value GLIDECLIENT_GROUP_WORK_DIR)
+if [ ! -d "$group_dir" ]; then
+    exit_hook_stop_pilot 303 "GLIDECLIENT_GROUP_WORK_DIR ($group_dir) is empty or not a directory"
+fi
+if [ -e "$group_dir/itb-ospool-lib" ]; then
+    source "$group_dir/itb-ospool-lib" || {
+        error_message="Unable to source itb-ospool-lib; group_dir is $group_dir; $(ls -ld "$group_dir" 2>&1); $(ls -ld "$group_dir/itb-ospool-lib" 2>&1)"
+        exit_hook_stop_pilot 304 "$error_message"
+    }
+else
+    source "$group_dir/ospool-lib" || {
+        error_message="Unable to source ospool-lib; group_dir is $group_dir; $(ls -ld "$group_dir" 2>&1); $(ls -ld "$group_dir/ospool-lib" 2>&1)"
+        exit_hook_stop_pilot 304 "$error_message"
+    }
+fi
+
+
+function download_or_build_singularity_image () {
+    local singularity_image="$1"
+
+    # ALLOW_NONCVMFS_IMAGES determines the approach here
+    # if it is 0, verify that the image is indeed on CVMFS
+    # if it is 1, transform the image to a form and try downloaded it from our services
+
+    # In addition, UNPACK_SIF determines whether a downloaded SIF image is
+    # expanded into the sandbox format (1) or used as-is (0).
+    info_dbg "Running download_or_build_singularity_image"
+
+    if [ "x$ALLOW_NONCVMFS_IMAGES" = "x0" ]; then
+        info_dbg "We do not allow non-CVMFS images"
+        if ! (echo "$singularity_image" | grep "^/cvmfs/") >/dev/null 2>&1; then
+            info_dbg "The specified image $singularity_image is not on CVMFS. Continuing anyways."
+            # allow this for now - we have user who ship images with their jobs
+            #return 1
+        fi
+        echo "$singularity_image"
+        return 0
+    else
+        info_dbg "We allow non-CVMFS images"
+        # first figure out a base image name in the form of owner/image:tag, then
+        # transform it to our expected image and name and try to download
+        singularity_srcs=""
+
+        if [[ $singularity_image = /cvmfs/singularity.opensciencegrid.org/* ]]; then
+            # transform /cvmfs to a set or URLS to to try
+            base_name=$(echo $singularity_image | sed 's;/cvmfs/singularity.opensciencegrid.org/;;' | sed 's;/*/$;;')
+            image_name=$(echo "$base_name" | sed 's;[:/];__;g')
+            week=$(date +'%V')
+            singularity_srcs="stash:///osgconnect/public/rynge/infrastructure/images/$week/sif/$image_name.sif http://stash.osgconnect.net/public/rynge/infrastructure/images/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
+        elif [[ -e "$singularity_image" ]]; then
+            # the image is not on cvmfs, but has already been downloaded - short circuit here
+            echo "$singularity_image"
+            return 0
+        else 
+            # user has been explicit with for example a docker or http URL
+            image_name=$(echo "$singularity_image" | sed 's;^[[:alnum:]]*://;;' | sed 's;[:/];__;g')
+            singularity_srcs="$singularity_image"
+        fi
+        # at this point image_name should be something like "opensciencegrid__osgvo-el8__latest"
+
+        local image_path="$GWMS_THIS_SCRIPT_DIR/images/$image_name"
+        info_dbg "Current image_path: $image_path"
+
+        # simple lock to prevent multiple slots from attempting dowloading of the same image
+        local lockfile="$image_path.lock"
+        (
+        flock -w 600 9
+
+        # already downloaded?
+        if [[ -e "$image_path" ]]; then
+            # even if we can use the sif, if we already have the sandbox, use that
+            echo "$image_path"
+            return 0
+        elif [[ -e "$image_path.sif" && $UNPACK_SIF = 0 ]]; then
+            # we already have the sif and we can use it
+            echo "$image_path.sif"
+            return 0
+        else
+            local tmptarget="$image_path.$$"
+            local logfile="$image_path.log"
+            local downloaded=0
+            rm -f $logfile
+
+            if [[ -e "$image_path.sif" && $UNPACK_SIF = 1 ]]; then
+                # we already have the sif but need to unpack it
+                # (this shouldn't happen very often)
+                if ("$GWMS_SINGULARITY_PATH" build --force --sandbox "$tmptarget" "$image_path.sif" ) &>>"$logfile"; then
+                    mv "$tmptarget" "$image_path"
+                    rm -f "$image_path.sif"
+                    echo "$image_path"
+                    return 0
+                else
+                    # unpack failed - sif may be damaged
+                    rm -f "$image_path.sif"
+                fi
+            fi
+
+            local tmptarget2
+            local image_path2
+            if [[ $UNPACK_SIF = 0 ]]; then
+                tmptarget2=$tmptarget.sif
+                image_path2=$image_path.sif
+            else
+                tmptarget2=$tmptarget
+                image_path2=$image_path
+            fi
+
+            for src in $singularity_srcs; do
+                echo "Trying to download from $src ..." &>>$logfile
+
+                if (echo "$src" | grep "^stash")>/dev/null 2>&1; then
+                    if (stash_download "$tmptarget2" "$src") &>>$logfile; then
+                        downloaded=1
+                        break
+                    fi
+
+                elif (echo "$src" | grep "^http")>/dev/null 2>&1; then
+                    if (http_download "$tmptarget2" "$src") &>>$logfile; then
+                        downloaded=1
+                        break
+                    fi
+
+                elif (echo "$src" | grep "^docker:" | grep -v "hub.opensciencegrid.org")>/dev/null 2>&1; then
+                    # docker is a special case - just pass it through
+                    # hub.opensciencegrid.org will be handled by "singularity build/pull" for now
+                    echo "$src"
+                    return 0
+
+                elif (echo "$src" | grep "://")>/dev/null 2>&1; then
+                    # some other url
+                    if [[ $UNPACK_SIF = 1 ]]; then
+                        if ($GWMS_SINGULARITY_PATH build --force --sandbox "$tmptarget2" "$src" ) &>>"$logfile"; then
+                            downloaded=1
+                            break
+                        fi
+                    else
+                        # "singularity pull" uses less CPU than "singularity build"
+                        # but $src must be a URL and it can't do --sandbox
+                        if ($GWMS_SINGULARITY_PATH pull --force "$tmptarget2" "$src" ) &>>"$logfile"; then
+                            downloaded=1
+                            break
+                        fi
+                    fi
+
+                else
+                    # we shouldn't have a local path at this point
+                    warn "Unexpected non-URL source '$src' for image $singularity_image"
+
+                fi
+                # clean up between attempts
+                rm -rf "$tmptarget2"
+            done
+            if [[ $downloaded = 1 ]]; then
+                mv "$tmptarget2" "$image_path2"
+            else
+                warn "Unable to download or build image ($singularity_image); logs:"
+                cat "$logfile" >&2
+                rm -rf "$tmptarget2"
+                return 1
+            fi
+            singularity_image=$image_path2
+            echo "$singularity_image"
+        fi
+        ) 9>$lockfile
+        return $?
+    fi
+}
+
+
+maybe_expand_cvmfs_image_path () {
+    # for /cvmfs based directory images, expand the path without symlinks so that
+    # the job can stay within the same image for the full duration
+    local image_path="$1"
+    if cvmfs_path_in_cvmfs "$image_path"; then
+        if (cd "$image_path") >/dev/null 2>&1; then
+            # This will fail for images that are not expanded in CVMFS, just ignore the failure
+            local new_image_path
+            new_image_path=$( (cd "$image_path" && pwd -P) 2>/dev/null )
+            if [[ -n "$new_image_path" ]]; then
+                echo "$new_image_path"
+                return
+            fi
+        fi
+    fi
+    # Image not in /cvmfs or failure to expand - return the original
+    echo "$image_path"
+}
+
+
+prepare_scratch_dir() {
+    # Copy $GWMS_DIR (bin, lib, ...) into the current directory (i.e. the scratch
+    # directory) which will be bind-mounted as /srv inside the container.
+    [[ -z "$GWMS_SUBDIR" ]] && { GWMS_SUBDIR=".gwms.d"; warn "GWMS_SUBDIR was undefined, setting to '.gwms.d'"; }
+    local gwms_dir=${GWMS_DIR:-"../../$GWMS_SUBDIR"}
+    if [[ -d "$gwms_dir" ]]; then
+        if mkdir -p "$GWMS_SUBDIR" && cp -r "$gwms_dir"/* "$GWMS_SUBDIR/"; then
+            # Should copy only lib and bin instead?
+            # TODO: change the message when condor_chirp requires no more special treatment
+            info_dbg "copied GlideinWMS utilities (bin and libs, including condor_chirp) inside the container ($(pwd)/$GWMS_SUBDIR)"
+        else
+            warn "Unable to copy GlideinWMS utilities inside the container (to $(pwd)/$GWMS_SUBDIR)"
+        fi
+    else
+        warn "Unable to find GlideinWMS utilities ($gwms_dir from $(pwd))"
+    fi
+
+    if [[ -n $SCRIPT_LOG && -f $SCRIPT_LOG ]]; then
+        mv -f "$SCRIPT_LOG" "$GWMS_SUBDIR/prepare-hook.log"
+    fi
+}
+
+
+output_new_classad_attrs () {
+    # Print classad attrs for condor to launch the job using container universe.
+    if [[ $GWMS_SINGULARITY_IMAGE ]]; then
+        echo "SingularityImage=\"$GWMS_SINGULARITY_IMAGE\""
+    fi
+}
+
+
+# Get things like GWMS_SINGULARITY_PATH from the glidein_config
+setup_from_environment
+
+SCRIPT_LOG="$PWD/.prepare-hook.log"  # for debugging
+
+info_dbg "Location of singularity: $GWMS_SINGULARITY_PATH"
+
+# Set up environment to know if HAS_SINGULARITY is enabled.
+setup_classad_variables
+GLIDEIN_DEBUG_OUTPUT=1
+
+# Check if singularity is disabled or enabled
+# This script could run when singularity is optional and not wanted
+# So should not fail but exec w/o running Singularity
+
+if [[ "x$HAS_SINGULARITY" != "x1"  ||  "x$GWMS_SINGULARITY_PATH" == "x" ]]; then
+    # No singularity needed; exit early.
+    msg="Singularity is not supported - continuing job without a container"
+    info_dbg "$msg"
+    exit_hook 0 "$msg"
+fi
+
+#############################################################################
+#
+# Will run w/ Singularity - prepare for it
+# From here on the script assumes it has to run w/ Singularity
+#
+info_dbg "Decided to use singularity ($HAS_SINGULARITY, $GWMS_SINGULARITY_PATH). Proceeding w/ tests and setup."
+
+# for mksquashfs
+PATH=$PATH:/usr/sbin
+
+# Should we use CVMFS or pull images directly?
+export ALLOW_NONCVMFS_IMAGES=$(get_prop_bool "$_CONDOR_MACHINE_AD" "ALLOW_NONCVMFS_IMAGES" 0)
+info_dbg "ALLOW_NONCVMFS_IMAGES: $ALLOW_NONCVMFS_IMAGES"
+
+# Should we use a sif file directly or unpack it first?
+# Rerun the test from osgvo-default-image and warn if the results don't match what's advertised.
+advertised_sif_support=$(get_prop_str "$_CONDOR_MACHINE_AD" "SINGULARITY_CAN_USE_SIF" "false" | tr A-Z a-z)
+if [[ $advertised_sif_support != "false" ]]; then
+    advertised_sif_support=1
+    UNPACK_SIF=0
+else
+    advertised_sif_support=0
+    UNPACK_SIF=1
+fi
+
+export UNPACK_SIF
+
+OSG_DEFAULT_SINGULARITY_IMAGE="$(get_glidein_config_value OSG_DEFAULT_SINGULARITY_IMAGE)"
+# Verify we have a default image and that it exists.
+# I am being very strict about this because
+# - OSG_DEFAULT_SINGULARITY_IMAGE should be defined in this glidein version
+# - the image should have been downloaded before the pilot started
+if [[ ! $OSG_DEFAULT_SINGULARITY_IMAGE ]]; then
+    # exit_hook_stop_pilot 305 "OSG_DEFAULT_SINGULARITY_IMAGE is not defined"
+    exit_hook_stop_pilot 5 "OSG_DEFAULT_SINGULARITY_IMAGE is not defined"  # DEBUG - put the job on hold
+elif [[ ! -e $OSG_DEFAULT_SINGULARITY_IMAGE ]]; then
+    # exit_hook_stop_pilot 306 "OSG_DEFAULT_SINGULARITY_IMAGE ($OSG_DEFAULT_SINGULARITY_IMAGE) does not exist as a local file/directory"
+    exit_hook_stop_pilot 6 "OSG_DEFAULT_SINGULARITY_IMAGE ($OSG_DEFAULT_SINGULARITY_IMAGE) does not exist as a local file/directory"  # DEBUG - put the job on hold
+fi
+
+if [[ $GWMS_SINGULARITY_IMAGE ]]; then
+    # TODO: Should we add a sanity check here? Maybe run file(1) or at least [[ -s $GWMS_SINGULARITY_IMAGE ]] ?
+    if [[ ! -e $GWMS_SINGULARITY_IMAGE ]]; then
+        # intercept and maybe download the image
+        orig_GWMS_SINGULARITY_IMAGE=$GWMS_SINGULARITY_IMAGE
+        GWMS_SINGULARITY_IMAGE=$(download_or_build_singularity_image "$orig_GWMS_SINGULARITY_IMAGE"); ret=$?
+        if [[ $ret != 0 ]]; then
+            # TODO add logs to the output
+            exit_hook $ret "Unable to download or build singularity image $orig_GWMS_SINGULARITY_IMAGE"
+        fi
+    fi
+
+    # Save the human readable version of the image before expanding it so we can use it in the exit message
+    # not exported -- vars exported in the job hook don't end up in the job
+    GWMS_SINGULARITY_IMAGE_HUMAN="$GWMS_SINGULARITY_IMAGE"
+    GWMS_SINGULARITY_IMAGE=$(maybe_expand_cvmfs_image_path "$GWMS_SINGULARITY_IMAGE")
+    msg="Using Singularity image $GWMS_SINGULARITY_IMAGE_HUMAN"
+else
+    msg="Using default Singularity image $OSG_DEFAULT_SINGULARITY_IMAGE"
+fi
+
+prepare_scratch_dir
+output_new_classad_attrs
+
+exit_hook 0 "$msg"

--- a/ospool-pilot/main-canary/job/simple-job-wrapper.sh
+++ b/ospool-pilot/main-canary/job/simple-job-wrapper.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# If we're inside Singularity, then make sure we set HOME and IWD correctly.
+# (N.B. - it's not 100% clear that this is needed.  Original comments around
+# this note that `--pwd` is unreliable in some versions of Singularity but not
+# when this was fixed.
+if [ ! -z "$SINGULARITY_NAME" ]; then
+    [[ -d /srv ]] && cd /srv
+    #export HOME=/srv
+    export OSG_WN_TMP=/tmp
+else
+    # OSPool: set up TMPDIR to be in the job dir; try to avoid /tmp at
+    # sites as some users tend to fill it up and disrupt the host.
+    #
+    # This is not done when inside Singularity as the equivalent is accomplished
+    # via bind mounts.
+    if [ "x$_CONDOR_SCRATCH_DIR" != "x" ]; then
+        TMPDIR="$_CONDOR_SCRATCH_DIR/.local-tmp"
+    else
+        TMPDIR=$(pwd)"/.local-tmp"
+    fi
+    export TMPDIR
+    export OSG_WN_TMP=$TMPDIR
+    mkdir -p $TMPDIR
+
+fi
+
+# Always make sure we have a reasonable PATH if it is not otherwise set.
+# Should be valid both inside and outside the container.
+export PATH=$PATH
+[[ -z "$PATH" ]] && export PATH="/usr/local/bin:/usr/bin:/bin"
+
+# GlideinWMS utility files and libraries - particularly condor_chirp
+if [[ -d "$PWD/.gwms.d/bin" ]]; then
+    # This includes the portable Python only condor_chirp
+    export PATH="$PWD/$GWMS_SUBDIR/bin:$PATH"
+fi
+
+# Some java programs have seen problems with the timezone in our containers.
+# If not already set, provide a default TZ
+[[ -z "$TZ" ]] && export TZ="UTC"
+
+exec "$@"

--- a/ospool-pilot/main-canary/pilot/additional-htcondor-config
+++ b/ospool-pilot/main-canary/pilot/additional-htcondor-config
@@ -53,9 +53,33 @@ add_config_line() {
 }
 # End add_config_line() patch
 
+
+set_unexported_condor_config_attribute () {
+    # Sets the value of a config knob in the condor config;
+    # does not export it as a startd attribute, nor does it export it to the job environment
+    # Reference: https://glideinwms.fnal.gov/doc.prd/factory/custom_vars.html
+    local name value
+    name=$1
+    value=$2
+    add_config_line "$name" "$value"
+    add_condor_vars_line "$name" \
+        "C" `# unquoted string (i.e. HTCondor keyword or expression)` \
+        "-" `# no default value` \
+        "+" `# also use $name for the name of the config knob` \
+        "N" `# a value is not required for this attribute` \
+        "N" `# do not have the startd publish this to the collector` \
+        "-" `# do not export to the user job environment`
+}
+
+
 condor_vars_file=`grep -i "^CONDOR_VARS_FILE " $glidein_config | awk '{print $2}'`
 
 ###########################################################
+# CVMFS_BASE defaults to /cvmfs but can be overridden in case of for example cvmfsexec
+if [[ ! $CVMFS_BASE ]]; then
+    CVMFS_BASE="/cvmfs"
+fi
+
 # enable job duration and busy stats
 add_config_line STATISTICS_TO_PUBLISH_LIST "JobDuration, JobBusyTime"
 add_condor_vars_line STATISTICS_TO_PUBLISH_LIST "C" "-" "+" "N" "N" "-"
@@ -87,23 +111,6 @@ if [[ $allocated_cpus -gt 0 && $total_cpus -gt 0 ]]; then
         add_condor_vars_line GLIDEIN_DISK "C" "-" "+" "N" "N" "-"
     fi
 fi
-
-set_unexported_condor_config_attribute () {
-    # Sets the value of a config knob in the condor config;
-    # does not export it as a startd attribute, nor does it export it to the job environment
-    # Reference: https://glideinwms.fnal.gov/doc.prd/factory/custom_vars.html
-    local name value
-    name=$1
-    value=$2
-    add_config_line "$name" "$value"
-    add_condor_vars_line "$name" \
-        "C" `# unquoted string (i.e. HTCondor keyword or expression)` \
-        "-" `# no default value` \
-        "+" `# also use $name for the name of the config knob` \
-        "N" `# a value is not required for this attribute` \
-        "N" `# do not have the startd publish this to the collector` \
-        "-" `# do not export to the user job environment`
-}
 
 # Hold jobs if they exceed allocated disk (OSPOOL-26)
 
@@ -226,6 +233,63 @@ if [ ! -z ${!envvar+x} ]; then
 fi
 
 done
+
+
+###########################################################
+# Find available volumes and set up bind mounts for Singularity jobs
+GLIDEIN_SINGULARITY_BINDPATH=`grep -i "^GLIDEIN_SINGULARITY_BINDPATH " $glidein_config | awk '{print $2}'`
+SINGULARITY_BIND_EXPR="/etc/hosts,/etc/localtime"
+OLDIFS=$IFS
+IFS=' ,'
+# shellcheck disable=SC2086
+for mntpoint in $GLIDEIN_SINGULARITY_BINDPATH "${CVMFS_BASE}:/cvmfs:ro" /etc/OpenCL/vendors; do
+    info "Checking Singularity bind $mntpoint"
+    # If we have a source:destination:flags type of bind, just test the source
+    mntsource=$(echo "$mntpoint" | cut -d: -f1)
+    if [[ -d $mntsource ]]; then
+        info "$mntsource found and is a directory; adding to SINGULARITY_BIND_EXPR"
+        # but put the whole bind in SINGULARITY_BIND_EXPR
+        SINGULARITY_BIND_EXPR="${SINGULARITY_BIND_EXPR},${mntpoint}"
+    else
+        info "$mntsource not found or not a directory; ignoring"
+    fi
+done
+IFS=$OLDIFS
+unset OLDIFS
+set_unexported_condor_config_attribute "SINGULARITY_BIND_EXPR" "\"${SINGULARITY_BIND_EXPR}\""
+info "SINGULARITY_BIND_EXPR is \"${SINGULARITY_BIND_EXPR}\""
+
+# Glideinwms used /srv as the scratch directory, we should do the same
+set_unexported_condor_config_attribute "SINGULARITY_TARGET_DIR" '/srv'
+set_unexported_condor_config_attribute "SINGULARITY_EXTRA_ARGUMENTS" '"--home $_CONDOR_SCRATCH_DIR:/srv"'
+set_unexported_condor_config_attribute "SINGULARITY_IMAGE_EXPR" '(SingularityImage ?: OSG_DEFAULT_SINGULARITY_IMAGE)'
+
+# Run all jobs in singularity if we have it
+set_unexported_condor_config_attribute "SINGULARITY_JOB" "(HAS_SINGULARITY?:false)"
+
+###########################################################
+# Add prepare hook to do the OSPool-specific transform of
+# the Singularity container outside of the glidein default
+# image.
+glidein_group_dir=`grep -i "^GLIDECLIENT_GROUP_WORK_DIR " $glidein_config | awk '{print $2}'`
+if [[ -e $glidein_group_dir/prepare-hook ]]; then
+    hook_path=$glidein_group_dir/prepare-hook
+else
+    hook_path=$glidein_group_dir/itb-prepare-hook-lib
+fi
+chmod +x "$hook_path"
+# TODO: these can all be replaced with set_unexported_condor_config_attribute
+add_config_line "OSPOOL_HOOK_PREPARE_JOB" "$hook_path"
+add_condor_vars_line "OSPOOL_HOOK_PREPARE_JOB" "C" "-" "OSPOOL_HOOK_PREPARE_JOB" "N" "N" "-"
+add_config_line "STARTER_JOB_HOOK_KEYWORD" "OSPOOL"
+add_condor_vars_line "STARTER_JOB_HOOK_KEYWORD" "C" "-" "STARTER_JOB_HOOK_KEYWORD" "N" "N" "-"
+add_config_line "OSPOOL_HOOK_PREPARE_JOB_TIMEOUT" "900"
+add_condor_vars_line "OSPOOL_HOOK_PREPARE_JOB_TIMEOUT" "C" "-" "OSPOOL_HOOK_PREPARE_JOB_TIMEOUT" "N" "N" "-"
+
+# debugging prepare job hook
+add_config_line "STARTER_DEBUG" "D_FULLDEBUG:2"
+add_condor_vars_line "STARTER_DEBUG" "C" "-" "STARTER_DEBUG" "N" "N" "-"
+
 ###########################################################
 
 echo "All done (osgvo-additional-htcondor-config)"

--- a/ospool-pilot/main-canary/pilot/advertise-base
+++ b/ospool-pilot/main-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=658
+OSG_GLIDEIN_VERSION=684
 #######################################################################
 
 

--- a/ospool.osg-htc.org/production/frontend-template.xml
+++ b/ospool.osg-htc.org/production/frontend-template.xml
@@ -371,7 +371,10 @@
             <file absfname="/opt/osg-flock/ospool-pilot/main-canary/pilot/additional-htcondor-config" after_entry="True" const="True" executable="True" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="False">
                <untar_options cond_attr="TRUE"/>
             </file>
-            <file absfname="/opt/osg-flock/ospool-pilot/main-canary/job/default_singularity_wrapper.sh" after_entry="True" const="True" executable="False" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="True">
+            <file absfname="/opt/osg-flock/ospool-pilot/main-canary/job/simple-job-wrapper.sh" after_entry="True" const="True" executable="False" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="True">
+               <untar_options cond_attr="TRUE"/>
+            </file>
+            <file absfname="/opt/osg-flock/ospool-pilot/itb/job/prepare-hook" after_entry="False" const="True" executable="False" period="0" prefix="NOPREFIX" untar="False" wrapper="False">
                <untar_options cond_attr="TRUE"/>
             </file>
          </files>


### PR DESCRIPTION
ospool-pilot scripts are taken from itb 684.
This adds the job/prepare-hook script and replaces job/default_singularity_wrapper.sh with job/simple-job-wrapper.sh.

frontend-template.xml is also updated to add the prepare-hook script.