### PR TITLE
Create a copy of the current 'ospool-pilot/main' scripts in 'ospool-pilot/old' and change the compat symlinks to link to there instead of main

### DIFF
--- a/job-wrappers/default_singularity_wrapper.sh
+++ b/job-wrappers/default_singularity_wrapper.sh
@@ -1,1 +1,1 @@
-../ospool-pilot/main/job/default_singularity_wrapper.sh
+../ospool-pilot/old/job/default_singularity_wrapper.sh

--- a/node-check/osgvo-additional-htcondor-config
+++ b/node-check/osgvo-additional-htcondor-config
@@ -1,1 +1,1 @@
-../ospool-pilot/main/pilot/additional-htcondor-config
+../ospool-pilot/old/pilot/additional-htcondor-config

--- a/node-check/osgvo-advertise-base
+++ b/node-check/osgvo-advertise-base
@@ -1,1 +1,1 @@
-../ospool-pilot/main/pilot/advertise-base
+../ospool-pilot/old/pilot/advertise-base

--- a/node-check/osgvo-advertise-userenv
+++ b/node-check/osgvo-advertise-userenv
@@ -1,1 +1,1 @@
-../ospool-pilot/main/pilot/advertise-userenv
+../ospool-pilot/old/pilot/advertise-userenv

--- a/node-check/osgvo-default-image
+++ b/node-check/osgvo-default-image
@@ -1,1 +1,1 @@
-../ospool-pilot/main/pilot/default-image
+../ospool-pilot/old/pilot/default-image

--- a/node-check/ospool-lib
+++ b/node-check/ospool-lib
@@ -1,1 +1,1 @@
-../ospool-pilot/main/lib/ospool-lib
+../ospool-pilot/old/lib/ospool-lib

--- a/node-check/singularity-extras
+++ b/node-check/singularity-extras
@@ -1,1 +1,1 @@
-../ospool-pilot/main/pilot/singularity-extras
+../ospool-pilot/old/pilot/singularity-extras

--- a/ospool-pilot/old/job/default_singularity_wrapper.sh
+++ b/ospool-pilot/old/job/default_singularity_wrapper.sh
@@ -1,0 +1,885 @@
+#!/bin/bash
+# GlideinWMS singularity wrapper. Invoked by HTCondor as user_job_wrapper
+# default_singularity_wrapper USER_JOB [job options and arguments]
+EXITSLEEP=10m
+GWMS_THIS_SCRIPT="$0"
+GWMS_THIS_SCRIPT_DIR=$(dirname "$0")
+
+# Directory in Singularity where auxiliary files are copied (e.g. singularity_lib.sh)
+GWMS_AUX_SUBDIR=${GWMS_AUX_SUBDIR:-".gwms_aux"}
+export GWMS_AUX_SUBDIR
+# GWMS_BASE_SUBDIR (directory where the base glidein directory is mounted) not defiled in Singularity for the user jobs, only for setup scripts
+# Directory to use for bin, lib, exec, ...
+GWMS_SUBDIR=${GWMS_SUBDIR:-".gwms.d"}
+export GWMS_SUBDIR
+
+# CVMFS_BASE defaults to /cvmfs but can be overridden in case of for example cvmfsexec
+if [ "x$CVMFS_BASE" = "x" ]; then
+    CVMFS_BASE="/cvmfs"
+fi
+
+GWMS_VERSION_SINGULARITY_WRAPPER=20201013
+# Updated using OSG wrapper #5d8b3fa9b258ea0e6640727405f20829d2c5d4b9
+# https://github.com/opensciencegrid/osg-flock/blob/master/job-wrappers/user-job-wrapper.sh
+# Link to the CMS wrapper
+# https://gitlab.cern.ch/CMSSI/CMSglideinWMSValidation/-/blob/master/singularity_wrapper.sh
+
+################################################################################
+#
+# All code out here will run on the 1st invocation (whether Singularity is wanted or not)
+# and also in the re-invocation within Singularity
+# $HAS_SINGLARITY is used to discriminate if Singularity is desired (is 1) or not
+# $GWMS_SINGULARITY_REEXEC is used to discriminate the re-execution (nothing outside, 1 inside)
+#
+
+# To avoid GWMS debug and info messages in the job stdout/err (unless userjob option is set)
+[[ ! ",${GLIDEIN_DEBUG_OPTIONS}," = *,userjob,* ]] && GLIDEIN_QUIET=True
+[[ ! ",${GLIDEIN_DEBUG_OPTIONS}," = *,nowait,* ]] && EXITSLEEP=2m  # leave 2min to update classad
+
+# When failing we need to tell HTCondor to put the job back in the queue by creating
+# a file in the PATH pointed by $_CONDOR_WRAPPER_ERROR_FILE
+# Make sure there is no leftover wrapper error file (if the file exists HTCondor assumes the wrapper failed)
+[[ -n "$_CONDOR_WRAPPER_ERROR_FILE" ]] && rm -f "$_CONDOR_WRAPPER_ERROR_FILE" >/dev/null 2>&1 || true
+
+
+exit_wrapper () {
+    # An error occurred. Communicate to HTCondor and avoid black hole (sleep for hold time) and then exit 1
+    #  1: Error message
+    #  2: Exit code (1 by default)
+    #  3: sleep time (default: $EXITSLEEP)
+    # The error is published to stderr, if available to $_CONDOR_WRAPPER_ERROR_FILE,
+    # if chirp available sets JobWrapperFailure
+    [[ -n "$1" ]] && warn_raw "ERROR: $1"
+    local exit_code=${2:-1}
+    local sleep_time=${3:-$EXITSLEEP}
+    local publish_fail
+
+    # signal other parts of the glidein that it is time to stop accepting jobs
+    touch $GWMS_THIS_SCRIPT_DIR/stop-glidein.stamp >/dev/null 2>&1
+
+    # Publish the error so that HTCondor understands that is a wrapper error and retries the job
+    if [[ -n "$_CONDOR_WRAPPER_ERROR_FILE" ]]; then
+        warn "Wrapper script failed, creating condor log file: $_CONDOR_WRAPPER_ERROR_FILE"
+        echo "Wrapper script $GWMS_THIS_SCRIPT failed ($exit_code): $1" >> $_CONDOR_WRAPPER_ERROR_FILE
+    else
+        publish_fail="HTCondor error file"
+    fi
+    
+    [[ -n "$publish_fail" ]] && warn "Failed to communicate ERROR with ${publish_fail}"
+
+    # Eventually the periodic validation of singularity will make the pilot
+    # to stop matching new payloads
+    # Prevent a black hole by sleeping EXITSLEEP (10) minutes before exiting. Sleep time can be changed on top of this file
+    sleep $sleep_time
+    exit $exit_code
+}
+
+# In case singularity_lib cannot be imported
+warn_raw () {
+    echo "$@" 1>&2
+}
+
+# Ensure all jobs have PATH set
+# bash can set a default PATH - make sure it is exported
+export PATH=$PATH
+[[ -z "$PATH" ]] && export PATH="/usr/local/bin:/usr/bin:/bin"
+
+[[ -z "$glidein_config" ]] && [[ -e "$GWMS_THIS_SCRIPT_DIR/glidein_config" ]] &&
+    export glidein_config="$GWMS_THIS_SCRIPT_DIR/glidein_config"
+
+# error_gen defined also in singularity_lib.sh
+[[ -e "$glidein_config" ]] && error_gen="$(grep '^ERROR_GEN_PATH ' "$glidein_config" | cut -d ' ' -f 2-)"
+
+# Source utility files, outside and inside Singularity
+# condor_job_wrapper is in the base directory, singularity_lib.sh in main
+# and copied to RUNDIR/$GWMS_AUX_SUBDIR (RUNDIR becomes /srv in Singularity)
+if [[ -e "$GWMS_THIS_SCRIPT_DIR/main/singularity_lib.sh" ]]; then
+    GWMS_AUX_DIR="$GWMS_THIS_SCRIPT_DIR/main"
+elif [[ -e /srv/$GWMS_AUX_SUBDIR/singularity_lib.sh ]]; then
+    # In Singularity
+    GWMS_AUX_DIR="/srv/$GWMS_AUX_SUBDIR"
+else
+    echo "ERROR: $GWMS_THIS_SCRIPT: Unable to source singularity_lib.sh! File not found. Quitting" 1>&2
+    warn=warn_raw
+    exit_wrapper "Wrapper script $GWMS_THIS_SCRIPT failed: Unable to source singularity_lib.sh" 1
+fi
+# shellcheck source=../singularity_lib.sh
+. "${GWMS_AUX_DIR}"/singularity_lib.sh
+
+# Directory to use for bin, lib, exec, ... full path
+if [[ -n "$GWMS_DIR" && -e "$GWMS_DIR/bin" ]]; then
+    # already set, keep it
+    true
+elif [[ -e $GWMS_THIS_SCRIPT_DIR/$GWMS_SUBDIR/bin ]]; then
+    GWMS_DIR=$GWMS_THIS_SCRIPT_DIR/$GWMS_SUBDIR
+elif [[ -e /srv/$GWMS_SUBDIR/bin ]]; then
+    GWMS_DIR=/srv/$GWMS_SUBDIR
+elif [[ -e /srv/$(dirname "$GWMS_AUX_DIR")/$GWMS_SUBDIR/bin ]]; then
+    GWMS_DIR=/srv/$(dirname "$GWMS_AUX_DIR")/$GWMS_SUBDIR/bin
+else
+    echo "ERROR: $GWMS_THIS_SCRIPT: Unable to find GWMS_DIR! (GWMS_THIS_SCRIPT_DIR=$GWMS_THIS_SCRIPT_DIR GWMS_SUBDIR=$GWMS_SUBDIR)" 1>&2
+    exit_wrapper "Wrapper script $GWMS_THIS_SCRIPT failed: Unable to find GWMS_DIR! (GWMS_THIS_SCRIPT_DIR=$GWMS_THIS_SCRIPT_DIR GWMS_SUBDIR=$GWMS_SUBDIR)" 1
+fi
+export GWMS_DIR
+
+# Calculating full version number, including md5 sums form the wrapper and singularity_lib
+GWMS_VERSION_SINGULARITY_WRAPPER="${GWMS_VERSION_SINGULARITY_WRAPPER}_$(md5sum "$GWMS_THIS_SCRIPT" 2>/dev/null | cut -d ' ' -f1)_$(md5sum "${GWMS_AUX_DIR}/singularity_lib.sh" 2>/dev/null | cut -d ' ' -f1)"
+info_dbg "GWMS singularity wrapper ($GWMS_VERSION_SINGULARITY_WRAPPER) starting, $(date). Imported singularity_lib.sh. glidein_config ($glidein_config)."
+info_dbg "$GWMS_THIS_SCRIPT, in $(pwd), list: $(ls -al)"
+
+function get_glidein_config_value {
+    # extracts a config attribute value from
+    # $1 is the attribute key
+    CF=$glidein_config
+    if [ -e "$CF.saved" ]; then
+        CF=$CF.saved
+    fi
+    KEY="$1"
+    VALUE=`(cat $CF | grep "^$KEY " | tail -n 1 | sed "s/^$KEY //") 2>/dev/null`
+    echo "$VALUE"
+}
+
+# OS Pool helpers
+# source our helpers
+if [[ $GWMS_SINGULARITY_REEXEC -ne 1 ]]; then
+    group_dir=$(get_glidein_config_value GLIDECLIENT_GROUP_WORK_DIR)
+    if [ ! -d "$group_dir" ]; then
+        exit_wrapper "GLIDECLIENT_GROUP_WORK_DIR ($group_dir) is empty or not a directory" 1
+    fi
+    if [ -e "$group_dir/itb-ospool-lib" ]; then
+        source "$group_dir/itb-ospool-lib" || {
+            error_message="Unable to source itb-ospool-lib; group_dir is $group_dir; $(ls -ld "$group_dir" 2>&1); $(ls -ld "$group_dir/itb-ospool-lib" 2>&1)"
+            exit_wrapper "$error_message" 1
+        }
+    else
+        source "$group_dir/ospool-lib" || {
+            error_message="Unable to source ospool-lib; group_dir is $group_dir; $(ls -ld "$group_dir" 2>&1); $(ls -ld "$group_dir/ospool-lib" 2>&1)"
+            exit_wrapper "$error_message" 1
+        }
+    fi
+fi
+
+
+download_or_build_singularity_image () {
+    local singularity_image="$1"
+
+    # ALLOW_NONCVMFS_IMAGES determines the approach here
+    # if it is 0, verify that the image is indeed on CVMFS
+    # if it is 1, transform the image to a form and try downloaded it from our services
+
+    # In addition, UNPACK_SIF determines whether a downloaded SIF image is
+    # expanded into the sandbox format (1) or used as-is (0).
+
+    if [ "x$ALLOW_NONCVMFS_IMAGES" = "x0" ]; then
+        if ! (echo "$singularity_image" | grep "^/cvmfs/") >/dev/null 2>&1; then
+            info_dbg "The specified image $singularity_image is not on CVMFS. Continuing anyways."
+            # allow this for now - we have user who ship images with their jobs
+            #return 1
+        fi
+    else
+        # first figure out a base image name in the form of owner/image:tag, then
+        # transform it to our expected image and name and try to download
+        singularity_srcs=""
+
+        if [[ $singularity_image = /cvmfs/singularity.opensciencegrid.org/* ]]; then
+            # transform /cvmfs to a set or URLS to to try
+            base_name=$(echo $singularity_image | sed 's;/cvmfs/singularity.opensciencegrid.org/;;' | sed 's;/*/$;;')
+            image_name=$(echo "$base_name" | sed 's;[:/];__;g')
+            week=$(date +'%V')
+            singularity_srcs="stash:///osgconnect/public/rynge/infrastructure/images/$week/sif/$image_name.sif http://stash.osgconnect.net/public/rynge/infrastructure/images/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
+        elif [[ -e "$singularity_image" ]]; then
+            # the image is not on cvmfs, but has already been downloaded - short circuit here
+            echo "$singularity_image"
+            return 0
+        else 
+            # user has been explicit with for example a docker or http URL
+            image_name=$(echo "$singularity_image" | sed 's;^[[:alnum:]]*://;;' | sed 's;[:/];__;g')
+            singularity_srcs="$singularity_image"
+        fi
+        # at this point image_name should be something like "opensciencegrid__osgvo-el8__latest"
+
+        local image_path="$GWMS_THIS_SCRIPT_DIR/images/$image_name"
+        # simple lock to prevent multiple slots from attempting dowloading of the same image
+        local lockfile="$image_path.lock"
+        local waitcount=0
+        while [[ -e $lockfile && $waitcount -lt 10 ]]; do
+            sleep 60s
+            waitcount=$(($waitcount + 1))
+        done
+
+        # already downloaded?
+        if [[ -e "$image_path" ]]; then
+            # even if we can use the sif, if we already have the sandbox, use that
+            echo "$image_path"
+            return 0
+        elif [[ -e "$image_path.sif" && $UNPACK_SIF = 0 ]]; then
+            # we already have the sif and we can use it
+            echo "$image_path.sif"
+            return 0
+        else
+            local tmptarget="$image_path.$$"
+            local logfile="$image_path.log"
+            local downloaded=0
+            touch $lockfile
+            rm -f $logfile
+
+            if [[ -e "$image_path.sif" && $UNPACK_SIF = 1 ]]; then
+                # we already have the sif but need to unpack it
+                # (this shouldn't happen very often)
+                if ("$GWMS_SINGULARITY_PATH" build --force --sandbox "$tmptarget" "$image_path.sif" ) &>>"$logfile"; then
+                    mv "$tmptarget" "$image_path"
+                    rm -f "$lockfile" "$image_path.sif"
+                    echo "$image_path"
+                    return 0
+                else
+                    # unpack failed - sif may be damaged
+                    rm -f "$image_path.sif"
+                fi
+            fi
+
+            local tmptarget2
+            local image_path2
+            if [[ $UNPACK_SIF = 0 ]]; then
+                tmptarget2=$tmptarget.sif
+                image_path2=$image_path.sif
+            else
+                tmptarget2=$tmptarget
+                image_path2=$image_path
+            fi
+
+            for src in $singularity_srcs; do
+                echo "Trying to download from $src ..." &>>$logfile
+
+                if (echo "$src" | grep "^stash")>/dev/null 2>&1; then
+                    if (stash_download "$tmptarget2" "$src") &>>$logfile; then
+                        downloaded=1
+                        break
+                    fi
+
+                elif (echo "$src" | grep "^http")>/dev/null 2>&1; then
+                    if (http_download "$tmptarget2" "$src") &>>$logfile; then
+                        downloaded=1
+                        break
+                    fi
+
+                elif (echo "$src" | grep "^docker:" | grep -v "hub.opensciencegrid.org")>/dev/null 2>&1; then
+                    # docker is a special case - just pass it through
+                    # hub.opensciencegrid.org will be handled by "singularity build/pull" for now
+                    rm -f "$lockfile"
+                    echo "$src"
+                    return 0
+
+                elif (echo "$src" | grep "://")>/dev/null 2>&1; then
+                    # some other url
+                    if [[ $UNPACK_SIF = 1 ]]; then
+                        if ($GWMS_SINGULARITY_PATH build --force --sandbox "$tmptarget2" "$src" ) &>>"$logfile"; then
+                            downloaded=1
+                            break
+                        fi
+                    else
+                        # "singularity pull" uses less CPU than "singularity build"
+                        # but $src must be a URL and it can't do --sandbox
+                        if ($GWMS_SINGULARITY_PATH pull --force "$tmptarget2" "$src" ) &>>"$logfile"; then
+                            downloaded=1
+                            break
+                        fi
+                    fi
+
+                else
+                    # we shouldn't have a local path at this point
+                    warn "Unexpected non-URL source '$src' for image $singularity_image"
+
+                fi
+                # clean up between attempts
+                rm -rf "$tmptarget2"
+            done
+            if [[ $downloaded = 1 ]]; then
+                mv "$tmptarget2" "$image_path2"
+            else
+                warn "Unable to download or build image ($singularity_image); logs:"
+                cat "$logfile" >&2
+                rm -rf "$tmptarget2" "$lockfile"
+                return 1
+            fi
+            singularity_image=$image_path2
+            rm -f "$lockfile"
+        fi
+    fi
+    echo "$singularity_image"
+    return 0
+}
+
+
+# overrideing this from singularity_lib.sh
+singularity_exec() {
+    # Return on stdout the command to invoke Singularity exec
+    # Change here for all invocations (both singularity_setup, wrapper). Custom options should go in the specific script
+    # In:
+    #  1 - singularity bin
+    #  2 - Singularity image path (constraints checked outside)
+    #  3 - Singularity binds (constraints checked outside)
+    #  4 - Singularity extra options (NOTE: this is not quoted, so spaces will be interpreted as separators)
+    #  5 - Singularity global options, before the exec command (NOTE: this is not quoted, so spaces will be interpreted as separators)
+    #  6 - Execution options: exec (exec singularity)
+    #  7 and more - Command to be executed and its options
+    #  PWD
+    # Out:
+    # Return:
+    #  string w/ command options on stdout
+    # Uses:
+    #  SINGULARITY_DISABLE_PID_NAMESPACES
+
+    local singularity_bin="$1"
+    local singularity_image="$2"
+    local singularity_binds="$3"
+    # Keeping --contain. Should not interfere w/ GPUs
+    local singularity_opts="--ipc --contain $4"  # extra options added at the end (still before binds)
+    # add --pid if not disabled in config
+    [[ $(gwms_from_config SINGULARITY_DISABLE_PID_NAMESPACES) = 1 ]] || singularity_opts+=" --pid"
+    local singularity_global_opts="$5"
+    local execution_opt="$6"
+    [[ -z "$singularity_image"  ||  -z "$singularity_bin" ]] && { warn "Singularity image or binary empty. Failing to run Singularity "; false; return; }
+    # TODO: to remove in the future (keeping only the else branch). This is for compatibility with default_singularity_wrapper.sh pre 3.4.6
+    if [[ "X$singularity_global_opts" = Xexec ]]; then
+        warn "default_singularity_wrapper.sh pre 3.4.6 running with 3.4.6 Factory scripts. Continuing in compatibility mode."
+        singularity_global_opts=
+        execution_opt="exec"
+        shift 5
+    else
+        shift 6
+    fi
+    # the remaining parameters are the command and parameters invoked by singularity
+    [[ -z "$1"  &&  $# -ne 0 ]] && { warn "Singularity invoked with an empty command. Failing."; false; return; }
+
+    # Make sure that ALL invocation strings and debug printout are same/consistent
+    # Quote all the path strings ($PWD, $singularity_bin, ...) to deal with a path that contains whitespaces
+    # CMS is not using "--home $PWD:/srv", OSG is
+    # New OSG: --bind $PWD:/srv --no-home (no --home \"$PWD\":/srv --pwd)
+    # TODO: --home or --no-home ? See email from Dave and Mats
+    # Dave: In versions 3.x through 3.2.1-1 where --home was being ignored on sites that set "mount home = no"
+    # in singularity.conf. This was fixed in 3.2.1-1.1.
+
+    info_dbg  "$execution_opt \"$singularity_bin\" $singularity_global_opts exec --home \"$PWD\":/srv --pwd /srv " \
+            "$singularity_opts ${singularity_binds:+"--bind" "\"$singularity_binds\""} " \
+            "\"$singularity_image\"" "${@}" "[ $# arguments ]"
+    local error
+    if [[ ",${execution_opt}," = *,exec,* ]]; then
+        exec "$singularity_bin" ${singularity_global_opts} exec --home "$PWD":/srv --pwd /srv \
+            ${singularity_opts} ${singularity_binds:+"--bind" "$singularity_binds"} \
+            "$singularity_image" "${@}"
+        error=$?
+        [[ -n "$_CONDOR_WRAPPER_ERROR_FILE" ]] && echo "Failed to exec singularity ($error): exec \"$singularity_bin\" $singularity_global_opts exec --home \"$PWD\":/srv --pwd /srv " \
+            "$singularity_opts ${singularity_binds:+"--bind" "\"$singularity_binds\""} " \
+            "\"$singularity_image\"" "${@}" >> $_CONDOR_WRAPPER_ERROR_FILE
+        warn "exec of singularity failed: exit code $error"
+        return ${error}
+    else
+        "$singularity_bin" ${singularity_global_opts} exec --home "$PWD":/srv --pwd /srv \
+            ${singularity_opts} ${singularity_binds:+"--bind" "$singularity_binds"} \
+            "$singularity_image" "${@}"
+        return $?
+    fi
+    # Code should never get here
+    warn "ERROR Inconsistency in Singularity invocation functions. Failing"
+    [[ -n "$_CONDOR_WRAPPER_ERROR_FILE" ]] && echo "ERROR: Inconsistency in GWMS Singularity invocation. Failing." >> $_CONDOR_WRAPPER_ERROR_FILE
+    exit 1
+}
+
+
+# OSGVO - overrideing this from singularity_lib.sh
+singularity_prepare_and_invoke() {
+    # Code moved into a function to allow early return in case of failure
+    # In case of failure: 1. it invokes singularity_exit_or_fallback which exits if Singularity is required
+    #   2. it interrupts itself and returns anyway
+    # The function returns in case the Singularity setup fails 
+    # In:
+    #   SINGULARITY_IMAGES_DICT: dictionary w/ Singularity images
+    #   $SINGULARITY_IMAGE_RESTRICTIONS: constraints on the Singularity image
+    # Using:
+    #   GWMS_SINGULARITY_IMAGE, 
+    #   or GWMS_SINGULARITY_IMAGE_RESTRICTIONS (SINGULARITY_IMAGES_DICT via singularity_get_image)
+    #      DESIRED_OS, GLIDEIN_REQUIRED_OS, REQUIRED_OS
+    #   $OSG_SITE_NAME (in monitoring)
+    #   GWMS_THIS_SCRIPT 
+    #   $GLIDEIN_Tmp_Dir GWMS_SINGULARITY_EXTRA_OPTS 
+    #   GWMS_SINGULARITY_OUTSIDE_PWD_LIST GWMS_SINGULARITY_OUTSIDE_PWD GWMS_THIS_SCRIPT_DIR _CONDOR_JOB_IWD
+    #   GWMS_BASE_SUBDIR - if defined will be bound to the glidein directory (will be accessible from singularity)
+    # Out:
+    #   GWMS_SINGULARITY_IMAGE GWMS_SINGULARITY_IMAGE_HUMAN GWMS_SINGULARITY_OUTSIDE_PWD_LIST SINGULARITY_WORKDIR GWMS_SINGULARITY_EXTRA_OPTS GWMS_SINGULARITY_REEXEC
+    # If  image is not provided, load the default one
+    # Custom URIs: http://singularity.lbl.gov/user-guide#supported-uris
+    
+    # Choose the singularity image
+    if [[ -z "$GWMS_SINGULARITY_IMAGE" ]]; then
+        # No image requested by the job
+        # Use OS matching to determine default; otherwise, set to the global default.
+        #  # Correct some legacy names? What if they are used in the dictionary?
+        #  REQUIRED_OS="`echo ",$REQUIRED_OS," | sed "s/,el7,/,rhel7,/;s/,el6,/,rhel6,/;s/,+/,/g;s/^,//;s/,$//"`"
+        DESIRED_OS=$(list_get_intersection "${GLIDEIN_REQUIRED_OS:-any}" "${REQUIRED_OS:-any}")
+        if [[ -z "$DESIRED_OS" ]]; then
+            msg="ERROR   VO (or job) REQUIRED_OS and Entry GLIDEIN_REQUIRED_OS have no intersection. Cannot select a Singularity image."
+            singularity_exit_or_fallback "$msg" 1
+            return
+        fi
+        if [[ "x$DESIRED_OS" = xany ]]; then
+            # Prefer the platforms default,rhel7,rhel6,rhel8, otherwise pick the first one available
+            GWMS_SINGULARITY_IMAGE=$(singularity_get_image default,rhel7,rhel6,rhel8 ${GWMS_SINGULARITY_IMAGE_RESTRICTIONS:+$GWMS_SINGULARITY_IMAGE_RESTRICTIONS,}any)
+        else
+            GWMS_SINGULARITY_IMAGE=$(singularity_get_image "$DESIRED_OS" $GWMS_SINGULARITY_IMAGE_RESTRICTIONS)
+        fi
+    fi
+
+    # At this point, GWMS_SINGULARITY_IMAGE is still empty, something is wrong
+    if [[ -z "$GWMS_SINGULARITY_IMAGE" ]]; then
+        msg="\
+ERROR   If you get this error when you did not specify required OS, your VO does not support any valid default Singularity image
+        If you get this error when you specified required OS, your VO does not support any valid image for that OS"
+        singularity_exit_or_fallback "$msg" 1
+        return
+    fi
+
+    # TODO: Custom images are not subject to SINGULARITY_IMAGE_RESTRICTIONS in OSG and CMS scripts. Should add a check here?
+    #if ! echo "$GWMS_SINGULARITY_IMAGE" | grep ^"/cvmfs" >/dev/null 2>&1; then
+    #    exit_wrapper "ERROR: $GWMS_SINGULARITY_IMAGE is not in /cvmfs area. Exiting" 1
+    #fi
+
+    # Whether user-provided or default image, we make sure it exists and make sure CVMFS has not fallen over
+    # TODO: better -e or ls?
+    #if ! ls -l "$GWMS_SINGULARITY_IMAGE/" >/dev/null; then
+    #if [[ ! -e "$GWMS_SINGULARITY_IMAGE" ]]; then
+    # will both work for non expanded images?
+
+    # check that the image is actually available (but only for /cvmfs ones)
+    if cvmfs_path_in_cvmfs "$GWMS_SINGULARITY_IMAGE"; then
+        if ! ls -l "$GWMS_SINGULARITY_IMAGE" >/dev/null; then
+            msg="\
+ERROR   Unable to access the Singularity image: $GWMS_SINGULARITY_IMAGE
+        Site and node: $OSG_SITE_NAME $(hostname -f)"
+            singularity_exit_or_fallback "$msg" 1 10m
+            return
+        fi
+    fi
+
+    if [[ "$GWMS_SINGULARITY_IMAGE" != *://* && ! -e "$GWMS_SINGULARITY_IMAGE" ]]; then
+        msg="\
+ERROR   Unable to access the Singularity image: $GWMS_SINGULARITY_IMAGE
+        Site and node: $OSG_SITE_NAME $(hostname -f)"
+        singularity_exit_or_fallback "$msg" 1 10m
+        return
+    fi
+
+    # Put a human readable version of the image in the env before expanding it - useful for monitoring
+    export GWMS_SINGULARITY_IMAGE_HUMAN="$GWMS_SINGULARITY_IMAGE"
+
+    # for /cvmfs based directory images, expand the path without symlinks so that
+    # the job can stay within the same image for the full duration
+    if cvmfs_path_in_cvmfs "$GWMS_SINGULARITY_IMAGE"; then
+        # Make sure CVMFS is mounted in Singularity
+        export GWMS_SINGULARITY_BIND_CVMFS=1
+        if (cd "$GWMS_SINGULARITY_IMAGE") >/dev/null 2>&1; then
+            # This will fail for images that are not expanded in CVMFS, just ignore the failure
+            local new_image_path
+            new_image_path=$( (cd "$GWMS_SINGULARITY_IMAGE" && pwd -P) 2>/dev/null )
+            if [[ -n "$new_image_path" ]]; then
+                GWMS_SINGULARITY_IMAGE=$new_image_path
+            fi
+        fi
+    fi
+
+    info_dbg "using image $GWMS_SINGULARITY_IMAGE_HUMAN ($GWMS_SINGULARITY_IMAGE)"
+    # Singularity image is OK, continue w/ other init
+
+    # set up the env to make sure Singularity uses the glidein dir for exported /tmp, /var/tmp
+    if [[ -n "$GLIDEIN_Tmp_Dir"  &&  -e "$GLIDEIN_Tmp_Dir" ]]; then
+        if mkdir "$GLIDEIN_Tmp_Dir/singularity-work.$$" ; then
+            export SINGULARITY_WORKDIR="$GLIDEIN_Tmp_Dir/singularity-work.$$"
+        else
+            warn "Unable to set SINGULARITY_WORKDIR to $GLIDEIN_Tmp_Dir/singularity-work.$$. Leaving it undefined."
+        fi
+    fi
+
+    GWMS_SINGULARITY_EXTRA_OPTS="$GLIDEIN_SINGULARITY_OPTS"
+
+    # Binding different mounts (they will be removed if not existent on the host)
+    # This is a dictionary in string w/ singularity mount options ("src1[:dst1[:opt1]][,src2[:dst2[:opt2]]]*"
+    # OSG: checks also in image, may not work if not expanded. And Singularity will not fail if missing, only give a warning
+    #  if [ -e $MNTPOINT/. -a -e $OSG_SINGULARITY_IMAGE/$MNTPOINT ]; then
+    GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS="/hadoop,/ceph,/hdfs,/lizard,/mnt/hadoop,/mnt/hdfs,/etc/hosts,/etc/localtime"
+
+    # CVMFS access inside container (default, but optional)
+    if [[ "x$GWMS_SINGULARITY_BIND_CVMFS" = "x1" ]]; then
+        GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS="`dict_set_val GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS /cvmfs`"
+    fi
+
+    # GPUs - bind outside OpenCL directory if available, and add --nv flag
+    if [[ "$OSG_MACHINE_GPUS" -gt 0  ||  "x$GPU_USE" = "x1" ]]; then
+        if [[ -e /etc/OpenCL/vendors ]]; then
+            GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS="`dict_set_val GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS /etc/OpenCL/vendors /etc/OpenCL/vendors`"
+        fi
+        GWMS_SINGULARITY_EXTRA_OPTS="$GWMS_SINGULARITY_EXTRA_OPTS --nv"
+    fi
+    info_dbg "bind-path default (cvmfs:$GWMS_SINGULARITY_BIND_CVMFS, hostlib:`[ -n "$HOST_LIBS" ] && echo 1`, ocl:`[ -e /etc/OpenCL/vendors ] && echo 1`): $GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS"
+
+    # We want to bind $PWD to /srv within the container - however, in order
+    # to do that, we have to make sure everything we need is in $PWD, most
+    # notably $GWMS_DIR (bin, lib, ...), the user-job-wrapper.sh (this script!) 
+    # and singularity_lib.sh (in $GWMS_AUX_SUBDIR)
+    #
+    # If gwms dir is present, then copy it inside the container
+    [[ -z "$GWMS_SUBDIR" ]] && { GWMS_SUBDIR=".gwms.d"; warn "GWMS_SUBDIR was undefined, setting to '.gwms.d'"; }
+    local gwms_dir=${GWMS_DIR:-"../../$GWMS_SUBDIR"}
+    if [[ -d "$gwms_dir" ]]; then
+        if mkdir -p "$GWMS_SUBDIR" && cp -r "$gwms_dir"/* "$GWMS_SUBDIR/"; then
+            # Should copy only lib and bin instead?
+            # TODO: change the message when condor_chirp requires no more special treatment
+            info_dbg "copied GlideinWMS utilities (bin and libs, including condor_chirp) inside the container ($(pwd)/$GWMS_SUBDIR)"
+        else
+            warn "Unable to copy GlideinWMS utilities inside the container (to $(pwd)/$GWMS_SUBDIR)"
+        fi
+    else
+        warn "Unable to find GlideinWMS utilities ($gwms_dir from $(pwd))"
+    fi
+    # copy singularity_lib.sh (in $GWMS_AUX_SUBDIR)
+    mkdir -p "$GWMS_AUX_SUBDIR"
+    cp "${GWMS_AUX_DIR}/singularity_lib.sh" "$GWMS_AUX_SUBDIR/"       
+    # mount the original glidein directory (for setup scripts only, not jobs)
+    if [[ -n "$GWMS_BASE_SUBDIR" ]]; then
+        # Make the glidein directory visible in singularity
+        mkdir -p "$GWMS_BASE_SUBDIR"
+        GWMS_SINGULARITY_WRAPPER_BINDPATHS_OVERRIDE="${GWMS_SINGULARITY_WRAPPER_BINDPATHS_OVERRIDE:+${GWMS_SINGULARITY_WRAPPER_BINDPATHS_OVERRIDE},}$( dirname "${GWMS_THIS_SCRIPT_DIR}"):/srv/$GWMS_BASE_SUBDIR"
+    fi
+    # copy the wrapper.sh (this script!)
+    if [[ "$GWMS_THIS_SCRIPT" == */main/singularity_wrapper.sh ]]; then
+        export JOB_WRAPPER_SINGULARITY="/srv/$GWMS_BASE_SUBDIR/main/singularity_wrapper.sh"
+    else
+        cp "$GWMS_THIS_SCRIPT" .gwms-user-job-wrapper.sh
+        export JOB_WRAPPER_SINGULARITY="/srv/.gwms-user-job-wrapper.sh"
+    fi
+
+    # Remember what the outside pwd dir is so that we can rewrite env vars
+    # pointing to somewhere inside that dir (for example, X509_USER_PROXY)
+    #if [[ -n "$_CONDOR_JOB_IWD" ]]; then
+    #    export GWMS_SINGULARITY_OUTSIDE_PWD="$_CONDOR_JOB_IWD"
+    #else
+    #    export GWMS_SINGULARITY_OUTSIDE_PWD="$PWD"
+    #fi
+    # Should this be GWMS_THIS_SCRIPT_DIR?
+    #   Problem at sites like MIT where the job is started in /condor/execute/.. hard link from
+    #   /export/data1/condor/execute/...
+    # Do not trust _CONDOR_JOB_IWD when it comes to finding pwd for the job - M.Rynge
+    GWMS_SINGULARITY_OUTSIDE_PWD="$PWD"
+    # Protect from jobs starting from linked or bind mounted directories
+    for i in "$_CONDOR_JOB_IWD" "$GWMS_THIS_SCRIPT_DIR"; do
+        if [[ "$i" != "$GWMS_SINGULARITY_OUTSIDE_PWD" ]]; then
+            [[ "$(robust_realpath "$i")" == "$GWMS_SINGULARITY_OUTSIDE_PWD" ]] && GWMS_SINGULARITY_OUTSIDE_PWD="$i"
+        fi
+    done
+    export GWMS_SINGULARITY_OUTSIDE_PWD="$GWMS_SINGULARITY_OUTSIDE_PWD"
+    GWMS_SINGULARITY_OUTSIDE_PWD_LIST="$(singularity_make_outside_pwd_list \
+        "${GWMS_SINGULARITY_OUTSIDE_PWD_LIST}" "${PWD}" "$(robust_realpath "${PWD}")" \
+        "${GWMS_THIS_SCRIPT_DIR}" "${_CONDOR_JOB_IWD}")"
+    export GWMS_SINGULARITY_OUTSIDE_PWD_LIST
+
+    # Build a new command line, with updated paths. Returns an array in GWMS_RETURN
+    singularity_update_path /srv "$@"
+
+    # Get Singularity binds, uses also GLIDEIN_SINGULARITY_BINDPATH, GLIDEIN_SINGULARITY_BINDPATH_DEFAULT
+    # remove binds w/ non existing src (e)
+    local singularity_binds
+    singularity_binds=$(singularity_get_binds e "$GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS" "$GWMS_SINGULARITY_WRAPPER_BINDPATHS_OVERRIDE")
+    # Run and log the Singularity command.
+    info_dbg "about to invoke singularity, pwd is $PWD"
+    export GWMS_SINGULARITY_REEXEC=1
+
+    # Always disabling outside LD_LIBRARY_PATH, PATH, PYTHONPATH and LD_PRELOAD to avoid problems w/ different OS
+    # Singularity is supposed to handle this, but different versions behave differently
+    # Restore them only if continuing after the exec of singularity failed (end of this function)
+    local old_ld_library_path=
+    if [[ -n "$LD_LIBRARY_PATH" ]]; then
+        old_ld_library_path=$LD_LIBRARY_PATH
+        info_dbg "GWMS Singularity wrapper: LD_LIBRARY_PATH is set to $LD_LIBRARY_PATH outside Singularity. This will not be propagated to inside the container instance." 1>&2
+        unset LD_LIBRARY_PATH
+    fi
+    local old_path=
+    #if [[ -n "$PATH" ]]; then
+    #    old_path=$PATH
+    #    info_dbg "GWMS Singularity wrapper: PATH is set to $PATH outside Singularity. This will not be propagated to inside the container instance." 1>&2
+    #    unset PATH
+    #fi
+    local old_pythonpath=
+    if [[ -n "$PYTHONPATH" ]]; then
+        old_pythonpath=$PYTHONPATH
+        info_dbg "GWMS Singularity wrapper: PYTHONPATH is set to $PYTHONPATH outside Singularity. This will not be propagated to inside the container instance." 1>&2
+        unset PYTHONPATH
+    fi
+    if [[ -n "$LD_PRELOAD" ]]; then
+        old_ld_preload=$LD_PRELOAD
+        info_dbg "GWMS Singularity wrapper: LD_PRELOAD is set to $LD_PRELOAD outside Singularity. This will not be propagated to inside the container instance." 1>&2
+        unset LD_PRELOAD
+    fi
+
+    # Add --clearenv if requested
+    GWMS_SINGULARITY_EXTRA_OPTS=$(env_clear "${GLIDEIN_CONTAINER_ENV}" "${GWMS_SINGULARITY_EXTRA_OPTS}")
+
+    # If there is clearenv protect the variables (it may also have been added by the custom Singularity options)
+    if env_gets_cleared "${GWMS_SINGULARITY_EXTRA_OPTS}" ; then
+        env_preserve "${GLIDEIN_CONTAINER_ENV}"
+    fi
+
+    # The new OSG wrapper is not exec-ing singularity to continue after and inspect if it ran correctly or not
+    # This may be causing problems w/ signals (sig-term/quit) propagation - [#24306]
+    if [[ -z "$GWMS_SINGULARITY_LIB_VERSION" ]]; then
+        # GWMS 3.4.5 or lower, no GWMS_SINGULARITY_GLOBAL_OPTS, no GWMS_SINGULARITY_LIB_VERSION
+        singularity_exec "$GWMS_SINGULARITY_PATH" "$GWMS_SINGULARITY_IMAGE" "$singularity_binds" \
+                 "$GWMS_SINGULARITY_EXTRA_OPTS" "exec" "$JOB_WRAPPER_SINGULARITY" \
+                 "${GWMS_RETURN[@]}"
+    else
+        singularity_exec "$GWMS_SINGULARITY_PATH" "$GWMS_SINGULARITY_IMAGE" "$singularity_binds" \
+                 "$GWMS_SINGULARITY_EXTRA_OPTS" "$GWMS_SINGULARITY_GLOBAL_OPTS" "exec" "$JOB_WRAPPER_SINGULARITY" \
+                 "${GWMS_RETURN[@]}"
+    fi
+    # Continuing here only if exec of singularity failed
+    GWMS_SINGULARITY_REEXEC=0
+    env_restore "${GLIDEIN_CONTAINER_ENV}"
+    # Restoring paths that are always cleared before invoking Singularity, 
+    # may contain something used for error communication
+    [[ -n "$old_path" ]] && PATH=$old_path
+    [[ -n "$old_ld_library_path" ]] && PATH=$old_ld_library_path
+    [[ -n "$old_pythonpath" ]] && PYTHONPATH=$old_pythonpath
+    [[ -n "$old_ld_preload" ]] && LD_PRELOAD=$old_ld_preload
+    # Exit or return to run w/o Singularity
+    singularity_exit_or_fallback "exec of singularity failed" $?
+}
+
+
+# OSGVO - overrideing this from singularity_lib.sh
+singularity_get_image() {
+    # Return on stdout the Singularity image
+    # Let caller decide what to do if there are problems
+    # In:
+    #  1: a comma separated list of platforms (OS) to choose the image
+    #  2: a comma separated list of restrictions (default: none)
+    #     - cvmfs: image must be on CVMFS
+    #     - any: any image is OK, $1 was just a preference (the first one in SINGULARITY_IMAGES_DICT is used if none of the preferred is available)
+    #  SINGULARITY_IMAGES_DICT
+    #  SINGULARITY_IMAGE_DEFAULT (legacy)
+    #  SINGULARITY_IMAGE_DEFAULT6 (legacy)
+    #  SINGULARITY_IMAGE_DEFAULT7 (legacy)
+    # Out:
+    #  Singularity image path/URL returned on stdout
+    #  EC: 0: OK, 1: Empty/no image for the desired OS (or for any), 2: File not existing, 3: restriction not met (e.g. image not on cvmfs)
+
+    local s_platform="$1"
+    if [[ -z "$s_platform" ]]; then
+        warn "No desired platform, unable to select a Singularity image"
+        return 1
+    fi
+    local s_restrictions="$2"
+    local singularity_image
+
+    # To support legacy variables SINGULARITY_IMAGE_DEFAULT, SINGULARITY_IMAGE_DEFAULT6, SINGULARITY_IMAGE_DEFAULT7
+    # values are added to SINGULARITY_IMAGES_DICT
+    # TODO: These override existing dict values OK for legacy support (in the future we'll add && [ dict_check_key rhel6 ] to avoid this)
+    [[ -n "$SINGULARITY_IMAGE_DEFAULT6" ]] && SINGULARITY_IMAGES_DICT="`dict_set_val SINGULARITY_IMAGES_DICT rhel6 "$SINGULARITY_IMAGE_DEFAULT6"`"
+    [[ -n "$SINGULARITY_IMAGE_DEFAULT7" ]] && SINGULARITY_IMAGES_DICT="`dict_set_val SINGULARITY_IMAGES_DICT rhel7 "$SINGULARITY_IMAGE_DEFAULT7"`"
+    [[ -n "$SINGULARITY_IMAGE_DEFAULT" ]] && SINGULARITY_IMAGES_DICT="`dict_set_val SINGULARITY_IMAGES_DICT default "$SINGULARITY_IMAGE_DEFAULT"`"
+
+    # [ -n "$s_platform" ] not needed, s_platform is never null here (verified above)
+    # Try a match first, then check if there is "any" in the list
+    singularity_image="`dict_get_val SINGULARITY_IMAGES_DICT "$s_platform"`"
+    if [[ -z "$singularity_image" && ",${s_platform}," = *",any,"* ]]; then
+        # any means that any image is OK, take the 'default' one and if not there the   first one
+        singularity_image="`dict_get_val SINGULARITY_IMAGES_DICT default`"
+        [[ -z "$singularity_image" ]] && singularity_image="`dict_get_first SINGULARITY_IMAGES_DICT`"
+    fi
+
+    # At this point, GWMS_SINGULARITY_IMAGE is still empty, something is wrong
+    if [[ -z "$singularity_image" ]]; then
+        [[ -z "$SINGULARITY_IMAGES_DICT" ]] && warn "No Singularity image available (SINGULARITY_IMAGES_DICT is empty)" ||
+                warn "No Singularity image available for the required platforms ($s_platform)"
+        return 1
+    fi
+
+    # TODO Reenable this based on ALLOW_NONCVMFS_IMAGES
+    # Check all restrictions (at the moment cvmfs) and return 3 if failing
+    #if [[ ",${s_restrictions}," = *",cvmfs,"* ]] && ! cvmfs_path_in_cvmfs "$singularity_image"; then
+    #    warn "$singularity_image is not in /cvmfs area as requested"
+    #    return 3
+    #fi
+
+    # We make sure it exists
+    #if [[ ! -e "$singularity_image" ]]; then
+    #    warn "ERROR: $singularity_image file not found" 1>&2
+    #    return 2
+    #fi
+
+    singularity_image=$(download_or_build_singularity_image "$singularity_image") || return 1
+    info_dbg "bind-path default (cvmfs:$GWMS_SINGULARITY_BIND_CVMFS, hostlib:$([ -n "$HOST_LIBS" ] && echo 1), ocl:$([ -e /etc/OpenCL/vendors ] && echo 1)): $GWMS_SINGULARITY_WRAPPER_BINDPATHS_DEFAULTS"
+
+    echo "$singularity_image"
+}
+
+
+#################### main ###################
+
+if [[ -z "$GWMS_SINGULARITY_REEXEC" ]]; then
+
+    ################################################################################
+    #
+    # Outside Singularity - Run this only on the 1st invocation
+    #
+
+    info_dbg "GWMS singularity wrapper, first invocation"
+
+    # Set up environment to know if Singularity is enabled and so we can execute Singularity
+    setup_classad_variables
+
+    # Check if singularity is disabled or enabled
+    # This script could run when singularity is optional and not wanted
+    # So should not fail but exec w/o running Singularity
+
+    if [[ "x$HAS_SINGULARITY" = "x1"  &&  "x$GWMS_SINGULARITY_PATH" != "x" ]]; then
+        #############################################################################
+        #
+        # Will run w/ Singularity - prepare for it
+        # From here on the script assumes it has to run w/ Singularity
+        #
+        info_dbg "Decided to use singularity ($HAS_SINGULARITY, $GWMS_SINGULARITY_PATH). Proceeding w/ tests and setup."
+
+        # for mksquashfs
+        PATH=$PATH:/usr/sbin
+
+        # Should we use CVMFS or pull images directly?
+        export ALLOW_NONCVMFS_IMAGES=$(get_prop_bool "$_CONDOR_MACHINE_AD" "ALLOW_NONCVMFS_IMAGES" 0)
+        info_dbg "ALLOW_NONCVMFS_IMAGES: $ALLOW_NONCVMFS_IMAGES"
+
+        # Should we use a sif file directly or unpack it first?
+        # Rerun the test from osgvo-default-image and warn if the results don't match what's advertised.
+        advertised_sif_support=$(get_prop_str "$_CONDOR_MACHINE_AD" "SINGULARITY_CAN_USE_SIF" "false" | tr A-Z a-z)
+        if [[ $advertised_sif_support != "false" ]]; then
+            advertised_sif_support=1
+        else
+            advertised_sif_support=0
+        fi
+
+        UNPACK_SIF=1
+        detected_sif_support=0
+        if check_singularity_sif_support &>/dev/null; then
+            detected_sif_support=1
+            UNPACK_SIF=0
+        fi
+        if [[ $advertised_sif_support != $detected_sif_support ]]; then
+            info_dbg "SIF support: advertised SINGULARITY_CAN_USE_SIF ${advertised_sif_support} != detected ${detected_sif_support}; using detected."
+        fi
+        export UNPACK_SIF
+
+        # OSGVO - disabled for now
+        # We make sure that every cvmfs repository that users specify in CVMFSReposList is available, otherwise this script exits with 1
+        #cvmfs_test_and_open "$CVMFS_REPOS_LIST" exit_wrapper
+
+        # OSGVO: unset modules leftovers from the site environment 
+        clearLmod --quiet 2>/dev/null 
+        unset -f spack
+        unset -f module
+        unset -f ml
+        for KEY in \
+              ENABLE_LMOD \
+              _LMFILES_ \
+              LOADEDMODULES \
+              MODULESHOME \
+              MODULE_USE \
+              module \
+              switchml \
+              $(env | sed 's/=.*//' | egrep "^MODULES_" 2>/dev/null) \
+              $(env | sed 's/=.*//' | egrep "^MODULEPATH" 2>/dev/null) \
+              $(env | sed 's/=.*//' | egrep "^LMOD" 2>/dev/null) \
+              $(env | sed 's/=.*//' | egrep "^SLURM" 2>/dev/null) \
+        ; do
+            eval VAL="\$$KEY"
+            if [ "x$VAL" != "x" ]; then
+                info_dbg "Unsetting env var provided by site: $KEY"
+            fi
+            unset $KEY
+        done
+
+        if [ "x$GWMS_SINGULARITY_IMAGE" != "x" ]; then
+            # intercept and maybe download the image
+            GWMS_SINGULARITY_IMAGE=$(download_or_build_singularity_image "$GWMS_SINGULARITY_IMAGE") || exit 1
+        fi
+
+        singularity_prepare_and_invoke "${@}"
+
+        # If we arrive here, then something failed in Singularity but is OK to continue w/o
+
+    else  #if [ "x$HAS_SINGULARITY" = "x1" -a "xSINGULARITY_PATH" != "x" ];
+        # First execution, no Singularity.
+        info_dbg "GWMS singularity wrapper, first invocation, not using singularity ($HAS_SINGULARITY, $GWMS_SINGULARITY_PATH)"
+    fi
+
+else
+    ################################################################################
+    #
+    # $GWMS_SINGULARITY_REEXEC not empty
+    # We are now inside Singularity
+    #
+
+    # Need to start in /srv (Singularity's --pwd is not reliable)
+    # /srv should always be there in Singularity, we set the option '--home \"$PWD\":/srv'
+    # TODO: double check robustness, we allow users to override --home
+    [[ -d /srv ]] && cd /srv
+    export HOME=/srv
+
+    # Changing env variables (especially TMP and X509 related) to work w/ chrooted FS
+    singularity_setup_inside
+    info_dbg "GWMS singularity wrapper, running inside singularity env = $(printenv)"
+
+fi
+
+################################################################################
+#
+# Setup for job execution
+# This section will be executed:
+# - in Singularity (if $GWMS_SINGULARITY_REEXEC not empty)
+# - if is OK to run w/o Singularity ( $HAS_SINGULARITY" not true OR $GWMS_SINGULARITY_PATH" empty )
+# - if setup or exec of singularity failed (and it is possible to fall-back to no Singularity)
+#
+
+info_dbg "GWMS singularity wrapper, final setup."
+
+gwms_process_scripts "$GWMS_DIR" prejob
+
+
+##############################
+#
+#  Cleanup
+#
+# Aux dir in the future mounted read only. Remove the directory if in Singularity
+# TODO: should always auxdir be copied and removed? Should be left for the job?
+[[ "$GWMS_AUX_SUBDIR/" == /srv/* ]] && rm -rf "$GWMS_AUX_SUBDIR/" >/dev/null 2>&1 || true
+rm -f .gwms-user-job-wrapper.sh >/dev/null 2>&1 || true
+
+
+##############################
+#
+#  OSPool: set up TMPDIR to be in the job dir
+#
+if [ "x$_CONDOR_SCRATCH_DIR" != "x" ]; then
+    TMPDIR="$_CONDOR_SCRATCH_DIR/local-tmp"
+else
+    TMPDIR=$(pwd)"/local-tmp"
+fi
+export TMPDIR
+mkdir -p $TMPDIR
+
+
+##############################
+#
+#  Run the real job
+#
+info_dbg "current directory at execution ($(pwd)): $(ls -al)"
+info_dbg "GWMS singularity wrapper, job exec: $*"
+info_dbg "GWMS singularity wrapper, messages after this line are from the actual job ##################"
+exec "$@"
+error=$?
+# exec failed. Log, communicate to HTCondor, avoid black hole and exit
+exit_wrapper "exec failed  (Singularity:$GWMS_SINGULARITY_REEXEC, exit code:$error): $*" $error

--- a/ospool-pilot/old/lib/ospool-lib
+++ b/ospool-pilot/old/lib/ospool-lib
@@ -1,0 +1,239 @@
+#!/bin/bash
+#
+# This script is script sources from multiple other scripts.
+# Only put functions in here
+#
+# Assumptions: "glidein_config" has been defined already
+#
+
+function info {
+    echo "INFO  $*" 1>&2
+}
+
+function my_warn {
+    echo "WARN   $*" 1>&2
+    export GLIDEIN_VALIDATION_WARNINGS="$@. $GLIDEIN_VALIDATION_WARNINGS"
+}
+
+function advertise {
+    # atype is the type of the value as defined by GlideinWMS:
+    #   I - integer
+    #   S - quoted string
+    #   C - unquoted string (i.e. Condor keyword or expression)
+    key="$1"
+    value="$2"
+    atype="$3"
+
+    if [ "$glidein_config" != "NONE" ]; then
+        add_config_line_safe $key "$value"
+        add_condor_vars_line $key "$atype" "-" "+" "Y" "Y" "-"
+    fi
+
+    if [ "$atype" = "S" ]; then
+        echo "$key = \"$value\""
+    else
+        echo "$key = $value"
+    fi
+}
+
+function check_singularity_overunderlay {
+    # some sites have broken singularity overlay/underlay
+    # test this by trying to bind pwd to a nonexistent directory
+    # in the container
+    local has_singularity=$(get_glidein_config_value HAS_SINGULARITY)
+    local singularity_path=$(get_glidein_config_value GWMS_SINGULARITY_PATH)
+    local default_image=$(get_glidein_config_value SINGULARITY_IMAGES_DICT | sed 's/^default://')
+
+    if [ "x$default_image" = "x" ]; then
+        default_image="/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-el8:latest/"
+    fi
+
+    # singularity is a prereq
+    if [[ $has_singularity != "True" ]]; then
+        return 0
+    fi
+
+    output=$(timeout 60s $singularity_path run -B $PWD:/doesnotexist $default_image /bin/true 2>&1)
+    ret=$?
+
+    if [[ $ret != 0 ]]; then
+        # DEBUGGING
+        info "Error testing for overlay/underlay; output:"
+        info "$output"
+        return $ret
+    else
+        return 0
+    fi
+}
+
+function check_singularity_overrides {
+    GLIDEIN_Entry_Name=$(get_glidein_config_value GLIDEIN_Entry_Name)
+    GLIDEIN_Site=$(get_glidein_config_value GLIDEIN_Site)
+    # AMNH-HEL - Singularity causes zombie process
+    # (https://support.opensciencegrid.org/a/tickets/69708)
+    if (echo "$GLIDEIN_Entry_Name" | egrep -i "AMNH-HEL") >/dev/null 2>&1; then
+        advertise HAS_SINGULARITY "False" "C"
+        advertise SINGULARITY_COMMENT "Disabled due to zombie process problem" "S"
+    fi
+    if (echo "$GLIDEIN_Site" | egrep -i "SDSC-PRP") >/dev/null 2>&1; then
+        advertise HAS_SINGULARITY "False" "C"
+        advertise SINGULARITY_COMMENT "Disabled due to singularity setup" "S"
+    fi
+}
+
+function stash_download {
+    # Use stashcp to download a sif file; if the destination does not end in .sif, unpack the sif into the sandbox format
+    local dest="$1"
+    local src="$2"
+
+    local dest_sif="${dest%.sif}.sif"
+    local client_dir=$(get_glidein_config_value GLIDECLIENT_WORK_DIR)
+
+    if [ -e $client_dir/stashcp ]; then
+        rm -rf "$dest" \
+            && $client_dir/stashcp "$src" "$dest_sif"
+        ret=$?
+    else
+        warn "stashcp is not available"
+        return 255
+    fi
+
+    if [[ $ret != 0 ]]; then
+        # delete on incomplete download
+        rm -f "$dest_sif"
+        return $ret
+    fi
+
+    if [[ "$dest_sif" != "$dest" ]]; then
+        $GWMS_SINGULARITY_PATH build --force --sandbox "$dest" "$dest_sif"
+        ret=$?
+        rm -f "$dest_sif"
+        return $ret
+    fi
+}
+
+function http_download {
+    # Use curl/wget to download a sif file; if the destination does not end in .sif, unpack the sif into the sandbox format
+    local dest="$1"
+    local src="$2"
+
+    local dest_sif="${dest%.sif}.sif"
+
+    if command -v curl >/dev/null 2>&1; then
+        curl --silent --verbose --show-error --fail --location --connect-timeout 30 --speed-limit 1024 -o "$dest_sif" "$src"
+        ret=$?
+    elif command -v wget >/dev/null 2>&1; then
+        wget -nv --timeout=30 --tries=1 -O "$dest_sif" "$src"
+        ret=$?
+    else
+        warn "Neither curl nor wget are available"
+        return 255
+    fi
+    if [[ $ret != 0 ]]; then
+        # delete on incomplete download
+        rm -f "$dest_sif"
+        return $ret
+    fi
+
+    if [[ "$dest_sif" != "$dest" ]]; then
+        $GWMS_SINGULARITY_PATH build --force --sandbox "$dest" "$dest_sif"
+        ret=$?
+        rm -f "$dest_sif"
+        return $ret
+    fi
+}
+
+
+function check_singularity_sif_support {
+    # Return 0 if singularity can directly run a .sif file without having to
+    # unpack it into a temporary sandbox first, nonzero otherwise.
+    #
+    # We know this needs setuid Singularity configured to allow loopback
+    # devices but there may be other conditions so just test it directly.
+
+    # Grab an alpine image from somewhere; ok to download each time since
+    # it's like 3 megs
+    local cvmfs_alpine="/cvmfs/stash.osgstorage.org/osgconnect/public/rynge/infrastructure/images/static/library__alpine__latest.sif"
+    local static_registry_alpine="docker://ospool-static-registry.osg.chtc.io/alpine:latest"
+    local sylabs_alpine="library://alpine:3"
+    local work_dir=$(get_glidein_config_value GLIDEIN_WORK_DIR)
+    local image_dir="$work_dir/../images"
+    local has_singularity=$(get_glidein_config_value HAS_SINGULARITY)
+    local singularity_path=$(get_glidein_config_value GWMS_SINGULARITY_PATH)
+
+    # do not allow .sif images on 3.x kernels (OSPOOL-18)
+    if (uname -r | egrep '^3\.') >/dev/null 2>&1; then
+        return 1
+    fi
+
+    # allow this to run before gwms has determined which singularity to use
+    if [[ $has_singularity = "" ]]; then
+        has_singularity="True"
+        singularity_path=singularity
+    fi
+
+    # singularity is a prereq
+    if [[ $has_singularity != "True" ]]; then
+        return 1
+    fi
+
+    # only download once
+    if [ ! -e $image_dir/gwms-alpine.sif.log ]; then
+        (cp "$cvmfs_alpine" $image_dir/gwms-alpine.sif ||
+             timeout 60s $singularity_path pull --force $image_dir/gwms-alpine.sif "$static_registry_alpine" ||
+             timeout 60s $singularity_path pull --force $image_dir/gwms-alpine.sif "$sylabs_alpine" ||
+             my_warn "All sources failed - could not create gwms-alpine.sif"
+        ) &> $image_dir/gwms-alpine.sif.log; ret=$?
+    fi
+
+    # did the download fail
+    if [ ! -e $image_dir/gwms-alpine.sif ]; then
+        return 1
+    fi
+
+    output=$(timeout 60s $singularity_path run $image_dir/gwms-alpine.sif /bin/true 2>&1)
+    ret=$?
+
+    if [[ $ret != 0 ]]; then
+        # DEBUGGING
+        info "Error testing for SIF support; output:"
+        info "$output"
+        return $ret
+    elif grep -q "temporary sandbox" <<< "$output"; then
+        info "Using a SIF created a temporary sandbox"
+        return 1
+    else
+        return 0
+    fi
+}
+
+function check_singularity_registry_support {
+    # Return 0 if singularity can directly run a registry image without having to
+    # unpack it into a temporary sandbox first, nonzero otherwise.
+    # This also tests building a SIF from a registry image
+    #
+    local static_registry_alpine="docker://ospool-static-registry.osg.chtc.io/alpine:latest"
+    local has_singularity=$(get_glidein_config_value HAS_SINGULARITY)
+    local singularity_path=$(get_glidein_config_value GWMS_SINGULARITY_PATH)
+
+    # singularity is a prereq
+    if [[ $has_singularity != "True" ]]; then
+        return 1
+    fi
+
+    output=$(timeout 60s $singularity_path run --disable-cache $static_registry_alpine /bin/true 2>&1)
+    ret=$?
+
+    if [[ $ret != 0 ]]; then
+        # DEBUGGING
+        info "Error testing for registry support; output:"
+        info "$output"
+        return $ret
+    elif grep -q "temporary sandbox" <<< "$output"; then
+        info "Using a registry created a temporary sandbox"
+        return 1
+    else
+        return 0
+    fi
+}
+

--- a/ospool-pilot/old/pilot/additional-htcondor-config
+++ b/ospool-pilot/old/pilot/additional-htcondor-config
@@ -1,0 +1,232 @@
+#!/bin/bash
+
+glidein_config="$1"
+
+function info {
+    echo "INFO  " $@ 1>&2
+}
+
+function warn {
+    echo "WARN  " $@ 1>&2
+}
+
+
+###########################################################
+# import add_config_line and add_condor_vars_line functions
+
+add_config_line_source=`grep '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}'`
+source $add_config_line_source
+
+# Patch over add_config_line() with a safer version
+# This will be fixed in gWMS 3.9.6
+add_config_line() {
+    # Ignore the call if the exact config line is already in there
+    if ! grep -q "^${*}$" "${glidein_config}"; then
+        # Use temporary files to make sure multiple add_config_line() calls don't clobber
+        # the glidein_config.
+        local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
+        local tmp_config1="${glidein_config}.$r.1"
+        local tmp_config2="${glidein_config}.$r.2"
+
+        # Copy the glidein config so it doesn't get modified while we grep out the old value
+        if ! cp -p "${glidein_config}" "${tmp_config1}"; then
+            warn "Error writing ${tmp_config1}"
+            rm -f "${tmp_config1}"
+            exit 1
+        fi
+        grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
+        rm -f "${tmp_config1}"
+        if [ ! -f "${tmp_config2}" ]; then
+            warn "Error creating ${tmp_config2}"
+            exit 1
+        fi
+        # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
+        echo "$@" >> "${tmp_config2}"
+
+        # Replace glidein config atomically
+        if ! mv -f "${tmp_config2}" "${glidein_config}"; then
+            warn "Error updating ${glidein_config} from ${tmp_config2}"
+            rm -f "${tmp_config2}"
+            exit 1
+        fi
+    fi
+}
+# End add_config_line() patch
+
+condor_vars_file=`grep -i "^CONDOR_VARS_FILE " $glidein_config | awk '{print $2}'`
+
+###########################################################
+# enable job duration and busy stats
+add_config_line STATISTICS_TO_PUBLISH_LIST "JobDuration, JobBusyTime"
+add_condor_vars_line STATISTICS_TO_PUBLISH_LIST "C" "-" "+" "N" "N" "-"
+
+# black holes, oh my (https://opensciencegrid.atlassian.net/browse/OSPOOL-3)
+add_config_line IsBlackHole "IfThenElse(RecentJobDurationAvg is undefined, false, RecentJobDurationCount >= 10 && RecentJobDurationAvg < 180)"
+add_condor_vars_line IsBlackHole "C" "-" "+" "N" "Y" "-"
+
+# excessive load, probably due to swapping (https://opensciencegrid.atlassian.net/browse/OSPOOL-2)
+add_config_line HasExcessiveLoad "LoadAvg > 2*DetectedCpus + 2"
+add_condor_vars_line HasExcessiveLoad "C" "-" "+" "N" "Y" "-"
+
+# out of disk space (https://opensciencegrid.atlassian.net/browse/OSPOOL-4)
+# note: Unlike DISK, RESERVED_DISK is in megabytes.
+# As of July 2022, the HTCondor manual incorrectly states this is in kilobytes.
+# This change was verified by examining the code.
+add_config_line RESERVED_DISK "3000"
+add_condor_vars_line RESERVED_DISK "C" "-" "+" "N" "N" "-"
+
+# use df and allocated cores to determine disk allocation (https://opensciencegrid.atlassian.net/browse/OSPOOL-5)
+# but only if we think we are not "whole node"
+allocated_cpus=$(grep -i "^GLIDEIN_CPUS " "$glidein_config" | cut -d ' ' -f 2-)
+total_cpus=$(cat /proc/cpuinfo | egrep "^processor" | wc -l)
+if [[ $allocated_cpus -gt 0 && $total_cpus -gt 0 ]]; then
+    #disk_free=$(df -kP . 2>/dev/null | awk '{if (NR==2) print $4}')
+    allocated_disk=$((100 * $allocated_cpus / $total_cpus))
+    if [[ $allocated_cpus -lt 32 ]]; then
+        add_config_line GLIDEIN_DISK "$allocated_disk%"
+        add_condor_vars_line GLIDEIN_DISK "C" "-" "+" "N" "N" "-"
+    fi
+fi
+
+set_unexported_condor_config_attribute () {
+    # Sets the value of a config knob in the condor config;
+    # does not export it as a startd attribute, nor does it export it to the job environment
+    # Reference: https://glideinwms.fnal.gov/doc.prd/factory/custom_vars.html
+    local name value
+    name=$1
+    value=$2
+    add_config_line "$name" "$value"
+    add_condor_vars_line "$name" \
+        "C" `# unquoted string (i.e. HTCondor keyword or expression)` \
+        "-" `# no default value` \
+        "+" `# also use $name for the name of the config knob` \
+        "N" `# a value is not required for this attribute` \
+        "N" `# do not have the startd publish this to the collector` \
+        "-" `# do not export to the user job environment`
+}
+
+# Hold jobs if they exceed allocated disk (OSPOOL-26)
+
+# Helper macros
+set_unexported_condor_config_attribute  disk_exceeded  '(JobUniverse != 13 && DiskUsage =!= UNDEFINED && DiskUsage > Disk)'
+set_unexported_condor_config_attribute  hold_reason_disk_exceeded  'disk usage exceeded request_disk'
+
+# Actual knobs. The following is the equivalent of
+# use POLICY : WANT_HOLD_IF(disk_exceeded, $(HOLD_SUBCODE_disk_exceeded:104), $(hold_reason_disk_exceeded))
+# since metaknobs are not supported.
+set_unexported_condor_config_attribute  PREEMPT  '$(disk_exceeded) || $(PREEMPT:false)'
+set_unexported_condor_config_attribute  MAXJOBRETIREMENTTIME  'ifthenelse($(disk_exceeded),-1,$(MAXJOBRETIREMENTTIME:0))'
+
+set_unexported_condor_config_attribute  WANT_SUSPEND  '$(disk_exceeded) =!= true && $(WANT_SUSPEND:false)'
+
+set_unexported_condor_config_attribute  WANT_HOLD  '(JobUniverse != 1 && $(disk_exceeded)) || $(WANT_HOLD:false)'
+set_unexported_condor_config_attribute  WANT_HOLD_SUBCODE  'ifThenElse($(disk_exceeded), 104 , $(WANT_HOLD_SUBCODE:UNDEFINED))'
+set_unexported_condor_config_attribute  WANT_HOLD_REASON  'ifThenElse($(disk_exceeded), "$(hold_reason_disk_exceeded)", $(WANT_HOLD_REASON:UNDEFINED))'
+
+# End OSPOOL-26
+
+###########################################################
+# potential fix for SU NAT issues
+add_config_line CCB_HEARTBEAT_INTERVAL "120"
+add_condor_vars_line CCB_HEARTBEAT_INTERVAL "C" "-" "+" "N" "N" "-"
+
+###########################################################
+# fix for chirp problem (Edgar)
+add_config_line CHIRP_DELAYED_UPDATE_PREFIX "Chirp*"
+add_condor_vars_line CHIRP_DELAYED_UPDATE_PREFIX "C" "-" "+" "N" "N" "-"
+
+###########################################################
+# debugging GSI
+#add_config_line MASTER_DEBUG "D_SECURITY:2"
+#add_condor_vars_line MASTER_DEBUG "C" "-" "+" "N" "N" "-"
+#add_config_line STARTD_DEBUG "D_SECURITY:2"
+#add_condor_vars_line STARTD_DEBUG "C" "-" "+" "N" "N" "-"
+#add_config_line STARTER_DEBUG "D_SECURITY:2"
+#add_condor_vars_line STARTER_DEBUG "C" "-" "+" "N" "N" "-"
+
+###########################################################
+# stashcp 
+STASHCP=$PWD/client/stashcp
+STASHCP_DEBUG="-d"
+STASHCP_TEST_FILE="/osgconnect/public/dweitzel/stashcp/test.file"
+STASH_PLUGIN=$PWD/client/stash_plugin
+chmod 755 $STASHCP $STASH_PLUGIN
+
+TIMEOUT=$(which timeout 2>/dev/null)
+if [ "x$TIMEOUT" != "x" ]; then
+    TIMEOUT="$TIMEOUT 120s"
+fi
+
+# The bash builtin time is no good because it pollutes
+# stderr with hardcoded real, sys, and user lines.
+TIME=$(which time 2>/dev/null)
+if [ "x$TIME" != "x" ]; then
+    # Without --quiet, newer versions of TIME(1)
+    # will prepend an extra line to the output
+    # if the process exits with a non-zero exit code.
+    # Therefore, we use $(tail -1 stashcp-test.time)
+    # below to get the runtime of stashcp.
+    TIME="$TIME --output=stashcp-test.time --format=%e"
+fi
+
+glidein_site=`grep -i "^GLIDEIN_Site " $glidein_config | awk '{print $2}'`
+if [[ -z $OSG_SITE_NAME ]]; then
+    OSG_SITE_NAME=$glidein_site
+fi
+
+# also run a simple test (TODO: make this IGWN-specific)
+info "Testing $STASHCP $STASHCP_DEBUG $STASHCP_TEST_FILE..."
+if $TIME $TIMEOUT $STASHCP $STASHCP_DEBUG $STASHCP_TEST_FILE stashcp-test.file >> stashcp-test.log 2>&1; then
+    if [ -f stashcp-test.time ]; then
+        info "Succeeded (in $(tail -1 stashcp-test.time)s)!"
+    else
+        info "Succeeded!"
+    fi
+    add_config_line FILETRANSFER_PLUGINS "\$(FILETRANSFER_PLUGINS),$STASH_PLUGIN"
+    add_condor_vars_line FILETRANSFER_PLUGINS "C" "-" "+" "N" "N" "-"
+else
+    if [ "$?" -eq "124" ]; then
+        warn "Failed (timed out after 120s)! stashcp output:"
+    elif [ -f stashcp-test.time ]; then
+        warn "Failed (in $(tail -1 stashcp-test.time)s)! stashcp output:"
+    else
+        warn "Failed! stashcp output:"
+    fi
+    while read line; do warn "$line"; done < stashcp-test.log
+fi
+
+##################################################################
+# Generate a minimal `STARTER_JOB_ENVIRONMENT`, mostly composed of
+# informational variables that are considered safe to always leak to
+# the job environment.
+#
+# Source of OSG_* variables:
+#   https://github.com/opensciencegrid/osg-configure/blob/dcd02313500cf113e8a6c27571197b4803295774/scripts/osg-configure#L27
+# Removed the following ones that don't appear actively used anymore:
+#  OSG_GRID, OSG_APP, OSG_DATA, OSG_SITE_READ, OSG_SITE_WRITE
+# Removed $OSG_WN_TMP because any job should use the HTCondor-provided scratch dir.
+# Considered and not passed through:
+#   LANG
+info "Calculating default job environment variables."
+
+job_env=
+for envvar in \
+     OSG_SITE_NAME \
+     OSG_HOSTNAME \
+     OSG_SQUID_LOCATION \
+     http_proxy \
+     https_proxy \
+     FTP_PROXY \
+     X509_USER_PROXY \
+; do
+
+if [ ! -z ${!envvar+x} ]; then
+  add_config_line "${envvar}" "${!envvar}"
+  add_condor_vars_line "${envvar}" "C" "-" "${envvar}" "N" "N" "+"
+fi
+
+done
+###########################################################
+
+echo "All done (osgvo-additional-htcondor-config)"
+

--- a/ospool-pilot/old/pilot/advertise-base
+++ b/ospool-pilot/old/pilot/advertise-base
@@ -1,0 +1,580 @@
+#!/bin/bash
+#
+# This script probes a system for properties useful for OSGVO and
+# friends. This particular script runs "outside" Singularity.
+#
+# To be able to support both
+# integration with GlideinWMS and HTCondor startd cron, argv1 is used
+# to determine what mode we are in. If argv1 points to a glidein_config
+# file, GlideinWMS mode is assumed. If argv1 is "NONE", HTCondor startd
+# cron mode is assumed.
+#
+# More information:
+#    http://www.uscms.org/SoftwareComputing/Grid/WMS/glideinWMS/doc.prd/factory/custom_scripts.html
+#    http://research.cs.wisc.edu/htcondor/manual/v8.2/4_4Hooks.html
+#
+# Example HTCondor startd cron entry:
+#
+# STARTD_CRON_JOBLIST = $(STARTD_CRON_JOBLIST) osgvo
+# STARTD_CRON_osgvo_EXECUTABLE = /opt/osgvo/osgvo-node-advertise
+# STARTD_CRON_osgvo_PERIOD = 30m
+# STARTD_CRON_osgvo_MODE = periodic
+# STARTD_CRON_osgvo_RECONFIG = true
+# STARTD_CRON_osgvo_KILL = true
+# STARTD_CRON_osgvo_ARGS = NONE
+
+#######################################################################
+#
+# Configuration
+#
+
+# OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
+# This can be used by negotiators or users, for example to match
+# against a glidein newer than some base with new features.
+OSG_GLIDEIN_VERSION=658
+#######################################################################
+
+
+glidein_config="$1"
+
+function info {
+    echo "INFO  " "$@" 1>&2
+}
+
+function my_warn {
+    echo "WARN  " "$@" 1>&2
+    export GLIDEIN_VALIDATION_WARNINGS="$*. $GLIDEIN_VALIDATION_WARNINGS"
+}
+
+function advertise {
+    # atype is the type of the value as defined by GlideinWMS:
+    #   I - integer
+    #   S - quoted string
+    #   C - unquoted string (i.e. Condor keyword or expression)
+    key="$1"
+    value="$2"
+    atype="$3"
+
+    if [ "$glidein_config" != "NONE" ]; then
+        add_config_line_safe $key "$value"
+        add_condor_vars_line $key "$atype" "-" "+" "Y" "Y" "-"
+    fi
+
+    if [ "$atype" = "S" ]; then
+        echo "$key = \"$value\""
+    else
+        echo "$key = $value"
+    fi
+}
+
+function get_glidein_config_value {
+    # extracts a config attribute value from 
+    # $1 is the attribute key
+    CF=$glidein_config
+    if [ "$glidein_config" = "NONE" ]; then
+        CF="$PWD/glidein_config"
+    fi
+    KEY="$1"
+    VALUE=`(cat $CF | grep "^$KEY " | tail -n 1 | sed "s/^$KEY //") 2>/dev/null`
+    echo "$VALUE"
+}
+
+
+
+###########################################################
+# Ensure only one copy of this script is running at the 
+# same time. For example, if a mount or something hangs
+# further down, we do not want more copies of this script
+# to add to the problem.
+
+export PID_FILE=osgvo-node-advertise.pid
+if [ -e $PID_FILE ]; then
+    OLD_PID=`cat $PID_FILE 2>/dev/null`
+    if kill -0 $OLD_PID >/dev/null 2>&1; then
+        exit 0
+    fi
+fi
+echo $$ >$PID_FILE
+
+#############################################################################
+# At least glideinWMS 3.7.5 depends on the existence of a file named
+# log/StarterLog.  However, starting in 8.9.13, this log file no longer is
+# created by HTCondor.  To fix the statistics reporting, we simply create it
+# here.
+mkdir -p log execute
+touch log/StarterLog
+
+###########################################################
+# We have two env variables which can be added to in this
+# script to provide an expression for the START expression
+# and a general warnings string which gets published in the
+# ad. These are env variables until the end.
+
+export GLIDEIN_VALIDATION_EXPR="True"
+export GLIDEIN_VALIDATION_WARNINGS=""
+
+#############################################################################
+#
+# Some tests are too heavy-weight to run every
+# 5 minutes. Such test can drop a file named $TEST_FILE_1H.NNNNNNN
+# in cwd. These files will be cleaned up after 60 minutes and allow the
+# test to rerun then again. There is also a 3 hour version.
+#
+
+TEST_FILE_1H=osgvo.test-results.1h
+TEST_FILE_4H=osgvo.test-results.4h
+
+# clean up old ones
+find . -maxdepth 1 -name $TEST_FILE_1H.\* -mmin +60 -exec rm {} \;
+find . -maxdepth 1 -name $TEST_FILE_4H.\* -mmin +240 -exec rm {} \;
+find . -maxdepth 1 -name adv-singularity-work.\* -mmin +240 -exec rm -rf {} \;
+
+info "This is a setup script for the OSPool frontend."
+info "In case of problems, contact Mats Rynge (rynge@isi.edu)"
+info "Running in directory $PWD"
+    
+if [ -e glidein_config ]; then
+    # gwms 
+    info "GWMS directory detected. Staying in $PWD"
+elif [ -e ../glidein_config ]; then
+    # gwms stupid tmp dir for periodic scripts - this breaks
+    # out ability to cache results
+    cd ../
+    info "GWMS tmp directory detected. Switched directory to $PWD"
+elif [ "x$LOCAL_DIR" != "x" ]; then
+    # osgvo-docker-pilot - use specified dir
+    cd $LOCAL_DIR
+    info "osgvo-docker-pilot \$LOCAL_DIR directory detected. Switched directory to $PWD"
+else
+    # find a good directory for our tests - we need something that we
+    # can re-enter later to pick up cached results
+    for DER in $GLIDEIN_Tmp_Dir $TMP $TMPDIR /tmp . ; do
+        # do we have write permissions
+        if touch $DER/.writetest.$$ >/dev/null 2>&1; then
+            rm -f $DER/.writetest.$$
+            if mkdir -p $DER/osgvo-node-advertise.work >/dev/null 2>&1; then
+                cp $0 $DER/osgvo-node-advertise.work/
+                if [ -e add_config_line.source ]; then
+                    cp add_config_line.source $DER/osgvo-node-advertise.work/
+                fi
+                cd $DER/osgvo-node-advertise.work
+                info "Switched working directory to $PWD"
+                break
+            fi
+        fi
+    done
+fi
+
+# bash can set a default PATH - make sure it is exported
+export PATH=$PATH
+
+# some sites do not have PATH set
+if [ "x$PATH" = "x" ]; then
+    export PATH="/usr/local/bin:/usr/bin:/bin"
+    my_warn "PATH is empty, setting it to $PATH"
+fi
+info "PATH is set to $PATH"
+
+# CVMFS_BASE defaults to /cvmfs but can be overridden in case of for example cvmfsexec
+if [ "x$CVMFS_BASE" = "x" ]; then
+    CVMFS_BASE="/cvmfs"
+fi
+
+if [ "x$glidein_config" = "x" ]; then
+    glidein_config="NONE"
+    info "No arguments provided - assuming HTCondor startd cron mode"
+else
+    info "Arguments to the script: $*"
+    if [ -e "$glidein_config.saved" ]; then
+        info "$glidein_config.saved found; not doing any more writes"
+        glidein_config="NONE"
+    fi
+fi
+
+if [ "$glidein_config" != "NONE" ]; then
+    ###########################################################
+    # import advertise and add_condor_vars_line functions
+    if [ "x$add_config_line_source" = "x" ]; then
+        export add_config_line_source=`grep '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}'`
+        export condor_vars_file=`grep -i "^CONDOR_VARS_FILE " $glidein_config | awk '{print $2}'`
+    fi
+
+    # full path is problematic as sometimes we are inside a container - however, looks like
+    # the file is always named "add_config_line.source", so use that
+    add_config_line_source=$PWD/add_config_line.source
+
+    info "Sourcing $add_config_line_source"
+    source $add_config_line_source
+
+    # XXX Patch over add_config_line() with a safer version
+    # This will be fixed in gWMS 3.9.6
+    add_config_line() {
+        # Ignore the call if the exact config line is already in there
+        if ! grep -q "^${*}$" "${glidein_config}"; then
+            # Use temporary files to make sure multiple add_config_line() calls don't clobber
+            # the glidein_config.
+            local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
+            local tmp_config1="${glidein_config}.$r.1"
+            local tmp_config2="${glidein_config}.$r.2"
+
+            # Copy the glidein config so it doesn't get modified while we grep out the old value
+            if ! cp -p "${glidein_config}" "${tmp_config1}"; then
+                warn "Error writing ${tmp_config1}"
+                rm -f "${tmp_config1}"
+                exit 1
+            fi
+            grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
+            rm -f "${tmp_config1}"
+            if [ ! -f "${tmp_config2}" ]; then
+                warn "Error creating ${tmp_config2}"
+                exit 1
+            fi
+            # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
+            echo "$@" >> "${tmp_config2}"
+
+            # Replace glidein config atomically
+            if ! mv -f "${tmp_config2}" "${glidein_config}"; then
+                warn "Error updating ${glidein_config} from ${tmp_config2}"
+                rm -f "${tmp_config2}"
+                exit 1
+            fi
+        fi
+    }
+    # XXX End add_config_line() patch
+fi
+
+# timeout, if available, is used across many tests
+TIMEOUT=$(which timeout 2>/dev/null)
+if [ "x$TIMEOUT" != "x" ]; then
+    TIMEOUT="$TIMEOUT 30s"
+fi
+
+advertise OSG_GLIDEIN_VERSION $OSG_GLIDEIN_VERSION "I"
+
+# we need the "outside" kernel version to be able to steer
+# singularity jobs to kernel/glibcs which are not too old
+VER=`uname -r | sed 's/-.*//'`
+MAJ=`echo $VER | sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+)/\1/'`
+MIN=`echo $VER | sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+)/\2/'`
+PATCH=`echo $VER | sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+)/\3/'`
+VER=$(( 10000 * $MAJ + 100 * $MIN + $PATCH ))
+if [ "x$VER" != "x" ]; then
+    if [ $VER -gt 10000 ]; then
+        advertise OSG_HOST_KERNEL_VERSION "$VER" "I"
+    fi
+fi
+
+# verify http_proxy/OSG_SQUID_LOCATION
+PROXY_CHECKS=0
+PROXY_LOCATION=""
+if [ -e $TEST_FILE_4H.http_proxy.checks ]; then
+    PROXY_CHECKS=$(cat $TEST_FILE_4H.http_proxy.checks)
+    PROXY_LOCATION=$(cat $TEST_FILE_4H.http_proxy.location)
+else
+    CURL=$(curl --version 2>/dev/null)
+    for PROXY_CANDIDATE in $http_proxy $OSG_SQUID_LOCATION; do
+        PROXY_CHECKS=$(($PROXY_CHECKS + 1))
+        if [ "x$CURL" != "x" ]; then
+            env http_proxy=$PROXY_CANDIDATE curl -s -m 10 -o /dev/null http://cm-1.ospool.osg-htc.org/overview/
+        else
+            env http_proxy=$PROXY_CANDIDATE wget -q --timeout 10 -O /dev/null http://cm-1.ospool.osg-htc.org/overview/
+        fi
+        if [ $? = 0 ]; then
+            PROXY_LOCATION="$PROXY_CANDIDATE"
+            break
+        fi
+    done
+    echo $PROXY_CHECKS >$TEST_FILE_4H.http_proxy.checks
+    echo $PROXY_LOCATION >$TEST_FILE_4H.http_proxy.location
+fi
+
+if [ "x$PROXY_LOCATION" = "x" -a $PROXY_CHECKS -gt 0 ]; then
+    # checks peformed, but failed - limit what file transfers we can do
+    advertise HasFileTransferPluginMethods "data,ftp,file" "S"
+fi
+if [ "x$PROXY_LOCATION" != "x" ]; then
+    advertise "http_proxy" "$PROXY_LOCATION" "S"
+fi
+
+# some images require unsquashfs
+HAS_unsquashfs="False"
+if unsquashfs -v >/dev/null 2>&1; then
+    HAS_unsquashfs="True"
+fi
+# singularity also looks in places which may not be in user PATH
+if [ -e /usr/sbin/unsquashfs ]; then
+    HAS_unsquashfs="True"
+fi
+advertise HAS_unsquashfs "$HAS_unsquashfs" "C"
+
+# check for locally cached .sif images - this will be helpful when determining 
+# we want to disable Singularity if CVMFS is not available
+GWMS_SINGULARITY_CACHED_IMAGES=$( (cd images/ && ls *.sif | sort | paste -d, -s) 2>/dev/null)
+if [[ "x$GWMS_SINGULARITY_CACHED_IMAGES" != "x" ]]; then
+    advertise GWMS_SINGULARITY_CACHED_IMAGES "$GWMS_SINGULARITY_CACHED_IMAGES" "S"
+fi
+
+
+function disk_is_full {
+    local dir_to_check="$1"
+    local required_space_gb="$2"
+    # some sites have tiny envs which could affect this test
+    # for example, undefined $HOME
+    if [ -z "$dir_to_check" ]; then
+        return 1
+    fi
+    # also ignore directories which do not exist
+    if [ ! -e "$dir_to_check" ]; then
+        return 1
+    fi
+    (( disk_free=$(df -kP "$dir_to_check" 2>/dev/null | awk '{if (NR==2) print $4}') ))
+    [[ $(( disk_free / 1024 / 1024 )) -lt $required_space_gb ]]
+}
+
+# check space in SINGULARITY_CACHEDIR and SINGULARITY_TMPDIR
+#
+cachedir_required_space_gb=5
+tmpdir_required_space_gb=5
+
+# ~/.singularity/cache might not have been created yet; if so, check its parents for disk space
+cachedir_to_check=${SINGULARITY_CACHEDIR:-$HOME/.singularity/cache}
+[[ -e $cachedir_to_check ]] || cachedir_to_check=$HOME/.singularity
+[[ -e $cachedir_to_check ]] || cachedir_to_check=$HOME
+tmpdir_to_check=${SINGULARITY_TMPDIR:-${TMPDIR:-/tmp}}
+
+if disk_is_full "$cachedir_to_check" "$cachedir_required_space_gb" || \
+    disk_is_full "$tmpdir_to_check" "$tmpdir_required_space_gb"
+then
+    advertise SINGULARITY_DISK_IS_FULL "True" C
+else
+    advertise SINGULARITY_DISK_IS_FULL "False" C
+fi
+
+
+##################
+# cvmfs filesystem availability
+GLIDEIN_Entry_Name=$(get_glidein_config_value GLIDEIN_Entry_Name)
+info "Checking for CVMFS availability and attributes..."
+for FS in \
+   ams.cern.ch \
+   atlas.cern.ch \
+   belle.cern.ch \
+   clicdp.cern.ch \
+   cms.cern.ch \
+   connect.opensciencegrid.org \
+   desdm.osgstorage.org \
+   eic.opensciencegrid.org \
+   gluex.osgstorage.org \
+   gwosc.osgstorage.org \
+   icecube.opensciencegrid.org \
+   icecube.osgstorage.org \
+   larsoft-ib.opensciencegrid.org \
+   larsoft.opensciencegrid.org \
+   nexo.opensciencegrid.org \
+   oasis.opensciencegrid.org \
+   sft.cern.ch \
+   singularity.opensciencegrid.org \
+   snoplus.egi.eu \
+   sphenix.opensciencegrid.org \
+   spt.opensciencegrid.org \
+   stash.osgstorage.org \
+   sw.lsst.eu \
+   unpacked.cern.ch \
+   veritas.opensciencegrid.org \
+   xenon.opensciencegrid.org \
+; do
+    FS_CONV=`echo "$FS" | sed 's/[\.-]/_/g'`
+    FS_ATTR="HAS_CVMFS_$FS_CONV"
+    RESULT="False"
+    
+    # keep the filesystems mounted
+    ls -l "$CVMFS_BASE"/$FS/ >/dev/null 2>&1
+
+    if [ -e $TEST_FILE_4H.cvmfs-disabled.$FS ]; then
+        advertise $FS_ATTR "False" "C"
+        if [ "x$FS" = "xsingularity.opensciencegrid.org" -a "x$GWMS_SINGULARITY_CACHED_IMAGES" = "x" ]; then
+            advertise HAS_SINGULARITY "False" "C"
+            advertise SINGULARITY_COMMENT "Disabled due to CVMFS availability/errors" "S"
+        fi
+        continue
+    fi
+
+    if [ -e $CVMFS_BASE/$FS/. ]; then
+        RESULT="True"
+
+        # add the revision 
+        REV_ATTR="CVMFS_${FS_CONV}_REVISION"
+        REV_VAL=`/usr/bin/attr -q -g revision "$CVMFS_BASE"/$FS/. 2>/dev/null`
+        # some site mount /cvmfs over NFS and attr will not work
+        if [ "x$REV_VAL" = "x" ]; then
+            REV_VAL=0
+        fi
+
+        # add the error count
+        NIOERR_ATTR="CVMFS_${FS_CONV}_NIOERR"
+        NIOERR_VAL=`/usr/bin/attr -q -g nioerr "$CVMFS_BASE"/$FS/. 2>/dev/null`
+        # some site mount /cvmfs over NFS and attr will not work
+        if [ "x$NIOERR_VAL" = "x" ]; then
+            NIOERR_VAL=-1
+        fi
+        
+        # disable if the mount has had errors
+        if [ $NIOERR_VAL -gt 0 ]; then
+            RESULT="False"
+        fi
+       
+        # UUTAH is special case - broken NFS
+        if (echo "$GLIDEIN_Entry_Name" | egrep -i "UUTAH") >/dev/null 2>&1; then
+            RESULT="False"
+        fi
+        
+        # oasis.opensciencegrid.org needs extra checks
+        if [ "x$FS" = "xoasis.opensciencegrid.org" ]; then
+            if ! cat "$CVMFS_BASE"/oasis.opensciencegrid.org/osg/sw/module-init.sh >/dev/null 2>&1; then
+                RESULT="False"
+            fi
+            if ! cat "$CVMFS_BASE"/oasis.opensciencegrid.org/sbgrid/update.details >/dev/null 2>&1; then
+                RESULT="False"
+            fi
+        fi
+
+        # stash.osgstorage.org needs extra checks
+        if [ "x$FS" = "xstash.osgstorage.org" ]; then
+            if ! cat "$CVMFS_BASE"/stash.osgstorage.org/osgconnect/public/rynge/glidein-checks/testfile >/dev/null 2>&1; then
+                RESULT="False"
+            fi
+        fi
+        
+        # veritas.opensciencegrid.org
+        if [ "x$FS" = "xveritas.opensciencegrid.org" ]; then
+            if ! cat "$CVMFS_BASE"/veritas.opensciencegrid.org/py2-v1/setup.sh >/dev/null 2>&1; then
+                RESULT="False"
+            fi
+        fi
+        
+        # disable singularity if the singularity cvmfs has errors
+        if [ "x$FS" = "xsingularity.opensciencegrid.org" -a "x$GWMS_SINGULARITY_CACHED_IMAGES" = "x" ]; then
+            if [ $RESULT = "False" ]; then
+                advertise HAS_SINGULARITY "False" "C"
+                advertise SINGULARITY_COMMENT "Disabled due to CVMFS availability/errors" "S"
+            fi
+        fi
+
+        # now we are ready to advertise
+        advertise $FS_ATTR "$RESULT" "C"
+        advertise $REV_ATTR "$REV_VAL" "I"
+        advertise $NIOERR_ATTR "$NIOERR_VAL" "I"
+
+        # remember failures - we want do not want to run on cvmfs if it comes and goes...
+        if [ $RESULT = "False" ]; then
+            touch $TEST_FILE_4H.cvmfs-disabled.$FS
+        fi
+    else
+        # $FS is not available
+        advertise $FS_ATTR "False" "C"
+        # remember failures - we want do not want to run on cvmfs if it comes and goes...
+        if [ $RESULT = "False" ]; then
+            touch $TEST_FILE_4H.cvmfs-disabled.$FS
+        fi
+    fi
+
+done
+
+# update timestamp?
+TS_ATTR="CVMFS_oasis_opensciencegrid_org_TIMESTAMP"
+TS_VAL=`(cat "$CVMFS_BASE"/oasis.opensciencegrid.org/osg/update.details  | egrep '^Update unix time:' | sed 's/.*: //') 2>/dev/null`
+if [ "x$TS_VAL" != "x" ]; then
+    # make sure it is an integer
+    if [ "$TS_VAL" -eq "$TS_VAL" ] 2>/dev/null; then
+        advertise $TS_ATTR "$TS_VAL" "I"
+    fi
+fi
+
+###########################################################
+# system attributes from the host
+
+VIRTUALIZATION=`(systemd-detect-virt) 2>/dev/null`
+if [ "x$VIRTUALIZATION" != "x" ]; then
+    advertise VIRTUALIZATION_TECHNOLOGY "$VIRTUALIZATION" "S"
+fi
+
+SHM_AVAILABLE=`(df /dev/shm --output=size --block-size=1k | tail -n 1) 2>/dev/null`
+if [ "x$SHM_AVAILABLE" != "x" ]; then
+    advertise SHM_AVAILABLE "$SHM_AVAILABLE" "I"
+fi
+
+
+##################
+# stashcp
+
+# this is a one-shot test
+rm -f stashcp-test.file
+chmod +x ./client/stashcp
+STASHCP_VERIFIED="False"
+if [ -e $TEST_FILE_1H.stashcp ]; then
+    STASHCP_VERIFIED=`cat $TEST_FILE_1H.stashcp`
+elif ($TIMEOUT ./client/stashcp /osgconnect/public/dweitzel/stashcp/test.file stashcp-test.file) >/dev/null 2>&1; then
+    STASHCP_VERIFIED="True"
+    echo "True" > $TEST_FILE_1H.stashcp
+else
+    echo "False" > $TEST_FILE_1H.stashcp
+fi
+rm -f testfile
+advertise STASHCP_VERIFIED "$STASHCP_VERIFIED" "C"
+
+# also record the version
+if [ -e ./client/stashcp ]; then
+    if [ ! -e $TEST_FILE_1H.stashcp-version ]; then
+        ./client/stashcp --version | grep '^Version:' | sed 's/.*: //' >$TEST_FILE_1H.stashcp-version
+    fi
+    VER=$(cat $TEST_FILE_1H.stashcp-version)
+    advertise STASHCP_VERSION "$VER" "S"
+fi
+
+if [ -z "$STASH_PLUGIN_PATH" ]; then
+    STASH_PLUGIN_PATH=$PWD/client/stash_plugin
+fi
+
+# also record the plugin version
+if [ -e "$STASH_PLUGIN_PATH" ]; then
+    chmod +x "$STASH_PLUGIN_PATH"
+    if [ ! -e $TEST_FILE_1H.stash-plugin-version ]; then
+        "$STASH_PLUGIN_PATH" -classad | awk '/^PluginVersion / { print $3 }' | sed 's/"//g' >$TEST_FILE_1H.stash-plugin-version
+    fi
+    VER=$(cat $TEST_FILE_1H.stash-plugin-version)
+    advertise STASH_PLUGIN_VERSION "$VER" "S"
+fi
+
+###########################################################
+# Project restriction
+if [[ -n $OSG_PROJECT_NAME ]]; then
+    info "OSG_PROJECT_NAME=$OSG_PROJECT_NAME"
+    advertise OSG_PROJECT_NAME "$OSG_PROJECT_NAME" "S"
+    advertise OSG_PROJECT_RESTRICTION "ProjectName =?= OSG_PROJECT_NAME" "C"
+else
+    info "OSG_PROJECT_NAME is unset"
+fi
+
+##################
+# mostly done - update START validation expressions and warnings attribute
+if [ -e stop-glidein.stamp -o -e ../stop-glidein.stamp ]; then
+    advertise OSG_NODE_VALIDATED "False" "C"
+    advertise OSG_NODE_WARNINGS "Node is shutting down due to stop-glidein file" "S"
+else
+    advertise OSG_NODE_VALIDATED "$GLIDEIN_VALIDATION_EXPR" "C"
+    if [ "x$GLIDEIN_VALIDATION_WARNINGS" != "x" ]; then
+        advertise OSG_NODE_WARNINGS "$GLIDEIN_VALIDATION_WARNINGS" "S"
+    fi
+fi
+
+##################
+
+# Save a backup copy of glidein_config that won't get clobbered by startd_crons; also use this as a sentinel
+# so subsequent runs of this script won't modify glidein_config if it exists.
+if [[ $glidein_config != "NONE" && ! -e "$glidein_config.saved" ]]; then
+    cp -p "$glidein_config" "$glidein_config.saved"
+fi
+
+rm -f $PID_FILE
+info "All done - time to do some real work!"
+

--- a/ospool-pilot/old/pilot/advertise-userenv
+++ b/ospool-pilot/old/pilot/advertise-userenv
@@ -1,0 +1,564 @@
+#!/bin/bash
+#
+# This script probes a system for properties useful for OSGVO and
+# friends. This particular script runs "inside" Singularity, in
+# the same environment as user jobs.
+#
+# To be able to support both
+# integration with GlideinWMS and HTCondor startd cron, argv1 is used
+# to determine what mode we are in. If argv1 points to a glidein_config
+# file, GlideinWMS mode is assumed. If argv1 is "NONE", HTCondor startd
+# cron mode is assumed.
+#
+# More information:
+#    http://www.uscms.org/SoftwareComputing/Grid/WMS/glideinWMS/doc.prd/factory/custom_scripts.html
+#    http://research.cs.wisc.edu/htcondor/manual/v8.2/4_4Hooks.html
+#
+# Example HTCondor startd cron entry:
+#
+# STARTD_CRON_JOBLIST = $(STARTD_CRON_JOBLIST) osgvo
+# STARTD_CRON_osgvo_EXECUTABLE = /opt/osgvo/osgvo-node-advertise
+# STARTD_CRON_osgvo_PERIOD = 30m
+# STARTD_CRON_osgvo_MODE = periodic
+# STARTD_CRON_osgvo_RECONFIG = true
+# STARTD_CRON_osgvo_KILL = true
+# STARTD_CRON_osgvo_ARGS = NONE
+
+#######################################################################
+#
+# Configuration
+#
+
+#######################################################################
+
+
+glidein_config="$1"
+
+function info {
+    echo "INFO  " $@ 1>&2
+}
+
+function my_warn {
+    echo "WARN  " $@ 1>&2
+}
+
+function advertise {
+    # atype is the type of the value as defined by GlideinWMS:
+    #   I - integer
+    #   S - quoted string
+    #   C - unquoted string (i.e. Condor keyword or expression)
+    key="$1"
+    value="$2"
+    atype="$3"
+
+    if [ "$glidein_config" != "NONE" ]; then
+        add_config_line_safe $key "$value"
+        add_condor_vars_line $key "$atype" "-" "+" "Y" "Y" "-"
+    fi
+
+    if [ "$atype" = "S" ]; then
+        echo "$key = \"$value\""
+    else
+        echo "$key = $value"
+    fi
+}
+
+function get_glidein_config_value {
+    # extracts a config attribute value from 
+    # $1 is the attribute key
+    CF=$glidein_config
+    if [ "$glidein_config" = "NONE" ]; then
+        CF="$PWD/glidein_config"
+    fi
+    KEY="$1"
+    VALUE=`(cat $CF | grep "^$KEY " | tail -n 1 | sed "s/^$KEY //") 2>/dev/null`
+    echo "$VALUE"
+}
+
+#############################################################################
+#
+# Some tests are too heavy-weight to run every
+# 5 minutes. Such test can drop a file named $TEST_FILE_1H.NNNNNNN
+# in cwd. These files will be cleaned up after 60 minutes and allow the
+# test to rerun then again. There is also a 3 hour version.
+#
+
+TEST_FILE_1H=osgvo.test-results.1h
+TEST_FILE_4H=osgvo.test-results.4h
+
+# clean up old ones
+find . -maxdepth 1 -name $TEST_FILE_1H.\* -mmin +60 -exec rm {} \;
+find . -maxdepth 1 -name $TEST_FILE_4H.\* -mmin +240 -exec rm {} \;
+find . -maxdepth 1 -name adv-singularity-work.\* -mmin +240 -exec rm -rf {} \;
+
+info "This is a setup script for the OSG-FLOCK frontend."
+info "In case of problems, contact Mats Rynge (rynge@isi.edu)"
+info "Running in directory $PWD"
+    
+if [ -e glidein_config ]; then
+    # gwms 
+    info "GWMS directory detected. Staying in $PWD"
+elif [ -e ../glidein_config ]; then
+    # gwms stupid tmp dir for periodic scripts - this breaks
+    # out ability to cache results
+    cd ../
+    info "GWMS tmp directory detected. Switched directory to $PWD"
+else
+    # find a good directory for our tests - we need something that we
+    # can re-enter later to pick up cached results
+    for DER in $GLIDEIN_Tmp_Dir $TMP $TMPDIR /tmp . ; do
+        # do we have write permissions
+        if touch $DER/.writetest.$$ >/dev/null 2>&1; then
+            rm -f $DER/.writetest.$$
+            if mkdir -p $DER/osgvo-node-advertise.work >/dev/null 2>&1; then
+                cp $0 $DER/osgvo-node-advertise.work/
+                if [ -e add_config_line.source ]; then
+                    cp add_config_line.source $DER/osgvo-node-advertise.work/
+                fi
+                cd $DER/osgvo-node-advertise.work
+                info "Switched working directory to $PWD"
+                break
+            fi
+        fi
+    done
+fi
+
+# bash can set a default PATH - make sure it is exported
+export PATH=$PATH
+
+# some sites do not have PATH set
+if [ "x$PATH" = "x" ]; then
+    export PATH="/usr/local/bin:/usr/bin:/bin"
+    my_warn "PATH is empty, setting it to $PATH"
+fi
+info "PATH is set to $PATH"
+
+# CVMFS_BASE defaults to /cvmfs but can be overridden in case of for example cvmfsexec
+if [ "x$CVMFS_BASE" = "x" ]; then
+    CVMFS_BASE="/cvmfs"
+fi
+
+if [ "x$glidein_config" = "x" ]; then
+    glidein_config="NONE"
+    info "No arguments provided - assuming HTCondor startd cron mode"
+else
+    info "Arguments to the script: $@"
+fi
+
+if [ "$glidein_config" != "NONE" ]; then
+    # full path is problematic as sometimes we are inside a container - however, looks like
+    # the file is always in pwd, so use that
+    export add_config_line_source=$PWD/add_config_line.source
+    export condor_vars_file=$PWD/main/condor_vars.lst
+
+    info "Sourcing $add_config_line_source"
+    source $add_config_line_source
+
+    # XXX Patch over add_config_line() with a safer version
+    # This will be fixed in gWMS 3.9.6
+    add_config_line() {
+        # Ignore the call if the exact config line is already in there
+        if ! grep -q "^${*}$" "${glidein_config}"; then
+            # Use temporary files to make sure multiple add_config_line() calls don't clobber
+            # the glidein_config.
+            local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
+            local tmp_config1="${glidein_config}.$r.1"
+            local tmp_config2="${glidein_config}.$r.2"
+
+            # Copy the glidein config so it doesn't get modified while we grep out the old value
+            if ! cp -p "${glidein_config}" "${tmp_config1}"; then
+                warn "Error writing ${tmp_config1}"
+                rm -f "${tmp_config1}"
+                exit 1
+            fi
+            grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
+            rm -f "${tmp_config1}"
+            if [ ! -f "${tmp_config2}" ]; then
+                warn "Error creating ${tmp_config2}"
+                exit 1
+            fi
+            # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
+            echo "$@" >> "${tmp_config2}"
+
+            # Replace glidein config atomically
+            if ! mv -f "${tmp_config2}" "${glidein_config}"; then
+                warn "Error updating ${glidein_config} from ${tmp_config2}"
+                rm -f "${tmp_config2}"
+                exit 1
+            fi
+        fi
+    }
+    # XXX End add_config_line() patch
+fi
+
+# timeout - need this early as we use it in some commands later
+HAS_TIMEOUT="False"
+TIMEOUT_CMD=""
+if /usr/bin/timeout --version >/dev/null 2>&1; then
+    HAS_TIMEOUT="True"
+    export TIMEOUT_CMD="/usr/bin/timeout 60"
+fi
+advertise HAS_TIMEOUT "$HAS_TIMEOUT" "C"
+
+# operating system
+
+# /etc/issue works most of the time, but there are exceptions
+OS_NAME=$(cat /etc/issue | head -n1 | awk '{print $1;}' | tr '[:lower:]' '[:upper:]')
+
+if [ "x$OS_NAME" = "xUBUNTU" ]; then
+    OS_VERSION=$(cat /etc/issue | head -n1 | grep -o -E ' [0-9]+.[0-9]+')
+elif [ -e /etc/debian_version ]; then
+    OS_NAME="DEBIAN"
+    OS_VERSION=`cat /etc/debian_version`
+elif [ "X$OS_NAME" = "xFEDORA" ]; then
+    OS_VERSION=`cat /etc/issue | head -n1 | awk '{print $3;}'`
+elif [ -e /etc/redhat-release ]; then
+    OS_NAME="RHEL"
+    OS_VERSION=`cat /etc/redhat-release | grep -o -E ' [0-9]+'`
+elif [ -e /etc/rocks-release ]; then
+    OS_NAME="RHEL"
+    OS_VERSION=`cat /etc/rocks-release | grep -o -E ' [0-9]+.[0-9]+'`
+elif [ -e /etc/SuSE-release ]; then
+    OS_NAME="SUSE"
+    OS_VERSION=`cat /etc/SuSE-release | grep VERSION | grep -o -E ' [0-9]+'`
+fi
+
+# remove spaces/tabs in the version
+OS_VERSION=`echo $OS_VERSION | sed 's/[ \t]//g'`
+
+# remove / in the version
+OS_VERSION=`echo $OS_VERSION | sed 's/\//_/g'`
+
+# we only want major version numbers
+OS_VERSION=`echo $OS_VERSION | sed 's/[\.-].*//'`
+
+if [ "x$OS_NAME" = "x" ]; then
+    OS_NAME="Unknown"
+fi
+if [ "x$OS_VERSION" = "x" ]; then
+    OS_VERSION="0"
+fi
+
+# kernel
+OS_KERNEL=`uname -r`
+if [ "x$OS_KERNEL" = "x" ]; then
+    OS_KERNEL="Unknown"
+fi
+
+advertise OSG_OS_NAME "$OS_NAME" "S"
+advertise OSG_OS_VERSION "$OS_VERSION" "S"
+advertise OSG_OS_STRING "$OS_NAME $OS_VERSION" "S"
+advertise OSG_OS_KERNEL "$OS_KERNEL" "S"
+
+# deprecated names
+advertise OSGVO_OS_NAME "$OS_NAME" "S"
+advertise OSGVO_OS_VERSION "$OS_VERSION" "S"
+advertise OSGVO_OS_STRING "$OS_NAME $OS_VERSION" "S"
+advertise OSGVO_OS_KERNEL "$OS_KERNEL" "S"
+
+# cpu info
+CPU_MODEL=`cat /proc/cpuinfo | grep -i "^model name" | head -n 1 | sed -r 's/[a-zA-Z \t]+:[ ]*//'`
+advertise OSG_CPU_MODEL "$CPU_MODEL" "S"
+advertise OSGVO_CPU_MODEL "$CPU_MODEL" "S"
+
+# some cpu flags HTCondor is not yet advertising
+for FLAG in `cat /proc/cpuinfo | egrep -i ^flags | head -n 1 | sed -r 's/[a-zA-Z \t]+:[ ]*//'`; do
+    if (echo "$FLAG" | egrep "avx512|cx16|f16c") >/dev/null 2>&1; then
+        advertise HAS_$FLAG "True" "C"
+    fi
+done
+
+# if we are in Singularity, override HTCondor's OsSys* vars with the
+# default container details
+if [ "x$SINGULARITY_COMMAND" != "x" ]; then
+    # RHEL is CentOS in HTCondor
+    if [ "x$OS_NAME" = "xRHEL" ]; then
+        OS_NAME="CentOS"
+    fi
+    advertise OpSysLongName "Singularity Container - $OS_NAME $OS_VERSION" "S"
+    advertise OpSysAndVer "${OS_NAME}${OS_VERSION}" "S"
+    advertise OpSysName "$OS_NAME" "S"
+    advertise OpSysShortName "$OS_NAME" "S"
+    advertise OpSysMajorVer "$OS_VERSION" "I"
+    advertise OpSysVer "${OS_VERSION}00" "I"
+fi
+
+##################
+# ulimits
+
+ULIMIT_STACK_SIZE=`(ulimit -s) 2>/dev/null`
+if [ "x$ULIMIT_STACK_SIZE" != "x" ]; then
+    if [ "X$ULIMIT_STACK_SIZE" = "Xunlimited" ]; then
+        ULIMIT_STACK_SIZE=-1
+    fi
+    advertise ULIMIT_STACK_SIZE "$ULIMIT_STACK_SIZE" "C"
+fi
+
+##################
+# stash
+if (cat /stash/user/test.osgconnect.1M) >/dev/null 2>&1; then
+    # ok, we can access stash, but is it ro or rw?
+    if (mount | grep " /stash" | grep ro) >/dev/null 2>&1; then
+        advertise StashReadOnly "True" "C"
+    else
+        advertise StashReadWrite "True" "C"
+    fi
+fi
+
+# advertise the version of stashcp found in $PATH
+if STASHCP_VERSION=$(stashcp --version)
+then
+    STASHCP_VERSION=$(echo "$STASHCP_VERSION" | head -n1 | grep -o "[0-9][0-9.]\+")
+    advertise STASHCP_VERSION "$STASHCP_VERSION" "S"
+else
+    # version check failed; we don't actually have a working stashcp
+    advertise STASHCP_VERSION UNDEFINED "C"
+    advertise STASHCP_VERIFIED "False" "C"
+fi
+
+##################
+# cms software
+
+info "Checking for CMS software..."
+OSGVO_CMSSW_Path=""
+if [ -r "$OSG_APP/cmssoft/cms/cmsset_default.sh" ]
+then
+    OSGVO_CMSSW_Path="$OSG_APP/cmssoft/cms/"
+elif [ -r $VO_CMS_SW_DIR/cmsset_default.sh ]
+then
+    OSGVO_CMSSW_Path="$VO_CMS_SW_DIR/"
+fi
+if [ "x$OSGVO_CMSSW_Path" != "x" ]
+then
+    advertise OSGVO_CMSSW_Path "$OSGVO_CMSSW_Path" "S"
+fi
+
+OSGVO_CMSSW_Revision=""
+if [ "x$OSGVO_CMSSW_Path" != "x" -a -r "$OSGVO_CMSSW_Path/etc/cms-common/revision" ]
+then
+    OSGVO_CMSSW_Revision=$(head -c 10 "$OSGVO_CMSSW_Path/etc/cms-common/revision")
+fi
+if [ "x$OSGVO_CMSSW_Revision" != "x" ]
+then
+    advertise OSGVO_CMSSW_Revision "$OSGVO_CMSSW_Revision - $OSGVO_CMSSW_Path/etc/cms-common/revision" "S"
+fi
+
+
+# modules
+RESULT="False"
+find . -maxdepth 1 -name $TEST_FILE_1H.modules -mmin +8 -exec rm {} \;
+if [ -e $TEST_FILE_1H.modules ]; then
+    RESULT=`cat $TEST_FILE_1H.modules`
+else
+   # extra check to make sure we can read a file
+   if cat "$CVMFS_BASE"/oasis.opensciencegrid.org/osg/README.txt >/dev/null 2>&1; then
+      if cat "$CVMFS_BASE"/connect.opensciencegrid.org/modules/spack/bin/spack >/dev/null 2>&1; then
+          if (. "$CVMFS_BASE"/oasis.opensciencegrid.org/osg/sw/module-init.sh && module avail) >/dev/null 2>&1; then
+              # also make sure module avail is not throwing a stack trace
+              if ! (. "$CVMFS_BASE"/oasis.opensciencegrid.org/osg/sw/module-init.sh && module avail 2>&1 | grep traceback) >/dev/null 2>&1; then
+                  RESULT="True"
+                  echo "True" > $TEST_FILE_1H.modules
+              else
+                  echo "False" > $TEST_FILE_1H.modules
+              fi
+          fi
+      fi
+   fi
+fi
+advertise HAS_MODULES "$RESULT && HAS_CVMFS_oasis_opensciencegrid_org && HAS_CVMFS_connect_opensciencegrid_org" "C"
+
+
+##################
+# Java - rely on HTCondor detection
+
+advertise HAS_JAVA "HasJava" "C"
+
+
+##################
+# basic tools
+
+for TOOL in \
+    scp \
+    rsync \
+    zip \
+    tcsh \
+    unzip \
+; do
+    if which $TOOL >/dev/null 2>&1; then
+        advertise HAS_$TOOL "True" "C"
+    else
+        advertise HAS_$TOOL "False" "C"
+    fi
+done
+
+##################
+# gfal
+
+# this is a one-shot test - this no longer works due to gwms delegating to 1024 bit
+# keys which are not accepted by EL8 hosts
+#GFAL_VERIFIED="False"
+#if [ -e $TEST_FILE_4H.gfal ]; then
+#    GFAL_VERIFIED=`cat $TEST_FILE_4H.gfal`
+#elif $TIMEOUT_CMD gfal-copy -t 10 -f gsiftp://workflow.isi.edu/dev/null file:///dev/null >/dev/null 2>&1; then
+#    GFAL_VERIFIED="True"
+#    echo "True" > $TEST_FILE_4H.gfal
+#else
+#    echo "False" > $TEST_FILE_4H.gfal
+#fi
+#advertise GFAL_VERIFIED "$GFAL_VERIFIED" "C"
+
+##################
+# guc
+
+GUC_PATH=`which globus-url-copy 2>/dev/null`
+if [ "X$GUC_PATH" = "X" ]; then
+    GUC_PATH="NA"
+fi
+advertise GUC_PATH "$GUC_PATH" "S"
+
+
+##################
+# xrdcp
+
+HAS_XRDCP="False"
+if xrdcp --version >/dev/null 2>&1; then
+    HAS_XRDCP="True"
+fi
+advertise HAS_XRDCP "$HAS_XRDCP" "C"
+
+
+
+##################
+# some basic libs
+for LIB in \
+    /lib64/libgcc_s.so.1 \
+    /lib64/libglib-2.0.so.0 \
+    /usr/lib64/atlas/libatlas.so.3 \
+    /usr/lib64/atlas/liblapack.so.3 \
+    /usr/lib64/atlas/libptf77blas.so.3 \
+    /usr/lib64/libgfortran.so.3 \
+    /usr/lib64/libglib-2.0.so \
+    /usr/lib64/libgmp.so.3 \
+    /usr/lib64/libgslcblas.so.0 \
+    /usr/lib64/libgsl.so.0 \
+    /usr/lib64/libgsl.so.0 \
+    /usr/lib64/libgtk-x11-2.0.so.0 \
+    /usr/lib64/libicuuc.so.42 \
+    /usr/lib64/libstdc++.so.6 \
+    /usr/lib64/libtk8.5.so \
+    /usr/lib64/libxcb.so.1 \
+    /usr/lib64/libXdmcp.so.6 \
+    /usr/lib64/libXm.so.4 \
+    /usr/lib64/libXmu.so.6 \
+    /usr/lib64/libXpm.so.4 \
+    /usr/lib64/libXt.so.6 \
+; do
+    ATTR="HAS_FILE"`echo $LIB | sed 's/[\.\/\+\-]/_/g'`
+    HAS_LIB="False"
+    if [ -e $LIB ]; then
+        HAS_LIB="True"
+    fi
+    advertise $ATTR "$HAS_LIB" "C"
+done
+
+# need a better way to figure this one out
+if [ -e /usr/share/doc/glib2-2.28.8 ]; then
+    advertise HAS_GLIB2_228 "True" "C"
+fi
+
+
+##################
+# gcc
+
+HAS_GCC="False"
+if gcc --version >/dev/null 2>&1; then
+    HAS_GCC="True"
+fi
+advertise HAS_GCC "$HAS_GCC" "C"
+
+HAS_GPP="False"
+if g++ --version >/dev/null 2>&1; then
+    HAS_GPP="True"
+fi
+advertise HAS_GPP "$HAS_GPP" "C"
+
+##################
+# R
+
+HAS_R="False"
+if R --version >/dev/null 2>&1; then
+    HAS_R="True"
+    R_VERSION=`(R --version 2>&1 | head -n1 | sed 's/"//g') 2>/dev/null`
+    if [ "x$R_VERSION" != "x" ]; then
+        advertise R_VERSION "$R_VERSION" "S"
+    fi
+fi
+advertise HAS_R "$HAS_R" "C"
+
+
+##################
+# python/numpy/scipy
+
+info "Checking for Python availability..."
+if python --version >/dev/null 2>&1; then
+    PYTHON_VERSION=`python --version 2>&1 | sed 's/Python //'`
+    if [ "x$PYTHON_VERSION" != "x" ]; then
+        advertise PYTHON_VERSION "$PYTHON_VERSION" "S"
+    fi
+    advertise HAS_PYTHON "True" "C"
+fi
+
+info "Checking for numpy/scipy availability..."
+cat >py.check <<EOF
+from numpy import array
+from os.path import exists
+from random import seed, shuffle
+from scipy.stats import chisquare
+from sys import argv
+EOF
+
+Has_Numpy_Scipy="False"
+if python py.check >/dev/null 2>&1; then
+    Has_Numpy_Scipy="True"
+fi
+advertise HAS_NUMPY "$Has_Numpy_Scipy" "C"
+rm -f py.check
+
+
+##################
+# matlab
+
+advertise MATLAB_COMPATIBLE "HAS_MODULES && HAS_FILE_usr_lib64_libXt_so_6" "C"
+
+
+##################
+# Blast
+
+info "Checking for blast availability..."
+
+APP_BASE=$OSG_APP/`whoami`/ncbi-blast-2.2.28+
+DATA_BASE=$OSG_DATA/`whoami`/blastdb
+
+HAS_BLAST="False"
+if [ -e "$APP_BASE/bin/blastp" -a -e "$DATA_BASE/nr.00.phr" ]; then
+
+    # let's do a specific test to make sure things work
+    export BLASTDB=$OSG_DATA/`whoami`/blastdb
+    export PATH=$APP_BASE/bin:$PATH
+    #echo ">test query" > test.fasta
+    #echo "ACGTCCGAGACGCGAGCAGCGAGCAGCAGAGCGACGAGCAGCGACGA" >> test.fasta
+    #if (blastp -db nr -query test.fasta) >/dev/null; then
+        HAS_BLAST="True"
+
+        # we also want to put the dirs in the environment
+        advertise BLAST_INSTALL_DIR "$APP_BASE" "S"
+
+        advertise BLAST_DB_DIR "$DATA_BASE" "S"
+    #fi
+fi
+advertise HAS_BLAST "$HAS_BLAST" "C"
+
+
+##################
+info "All done - time to do some real work!"
+

--- a/ospool-pilot/old/pilot/default-image
+++ b/ospool-pilot/old/pilot/default-image
@@ -1,0 +1,216 @@
+#!/bin/bash
+#
+# This script selects a default image for a glidein. In the fe config,
+# specify a distribution for both regular and gpu slots. Example:
+#
+#   <attr name="OSG_DEFAULT_CONTAINER_DISTRIBUTION" glidein_publish="False" job_publish="False" parameter="True" type="string" value="25%__opensciencegrid/osgvo-el7:latest 25%__opensciencegrid/osgvo-ubuntu-18.04:latest 25%__opensciencegrid/osgvo-el8:latest 25%__opensciencegrid/osgvo-ubuntu-20.04:latest"/>
+#   <attr name="OSG_DEFAULT_CONTAINER_DISTRIBUTION_GPU" glidein_publish="False" job_publish="False" parameter="True" type="string" value="100%__opensciencegrid/osgvo-el7-cuda10:latest"/>
+#
+
+glidein_config="$1"
+export glidein_config
+
+# make sure we do not put images in /tmp
+export TMPDIR="$PWD/tmp"
+mkdir -p $TMPDIR
+
+function get_glidein_config_value {
+    # extracts a config attribute value from 
+    # $1 is the attribute key
+    CF=$glidein_config
+    if [ "$glidein_config" = "NONE" ]; then
+        CF="$PWD/glidein_config"
+    fi
+    KEY="$1"
+    VALUE=`(cat $CF | grep "^$KEY " | tail -n 1 | sed "s/^$KEY //") 2>/dev/null`
+    echo "$VALUE"
+}
+
+function determine_default_container_image {
+    # Selects a default image to use if a job does not specify
+    # an image to use. The new style to specify this is with an
+    # attribute named OSG_DEFAULT_CONTAINER_DISTRIBUTION
+    # Example:
+    # 70%__opensciencegrid/osgvo-el7:latest 20%__opensciencegrid/osgvo-el6:latest 8%__opensciencegrid/osgvo-ubuntu-18.04:latest 2%__opensciencegrid/osgvo-debian-10:latest 
+
+    OSG_DEFAULT_CONTAINER_DISTRIBUTION=`get_glidein_config_value OSG_DEFAULT_CONTAINER_DISTRIBUTION`
+    OSG_SINGULARITY_EL7_PERCENT=`get_glidein_config_value OSG_SINGULARITY_EL7_PERCENT`
+
+    # if we are given GPUs, pick up GPU specific images
+    if [ "x$CUDA_VISIBLE_DEVICES" != "x" -o "x$NVIDIA_VISIBLE_DEVICES" != "x" ]; then
+        OSG_DEFAULT_CONTAINER_DISTRIBUTION=`get_glidein_config_value OSG_DEFAULT_CONTAINER_DISTRIBUTION_GPU`
+    fi
+
+    SELECTED_IMAGE=""
+    if [ "x$OSG_DEFAULT_CONTAINER_DISTRIBUTION" != "x" ]; then
+        # new style - weighted random selection
+        TARGET=$(($RANDOM % 100 + 1))
+        TOTAL_PERCENT=0
+        for ENTRY in $OSG_DEFAULT_CONTAINER_DISTRIBUTION; do
+            PERCENT=`echo $ENTRY | sed 's/%__.*//'`
+            IMAGE=`echo $ENTRY | sed 's/.*%__//'`
+            # we just need to track the upper limit
+            TOTAL_PERCENT=$(($TOTAL_PERCENT + $PERCENT))
+            if [ $TARGET -le $TOTAL_PERCENT ]; then
+                SELECTED_IMAGE=$IMAGE
+                break
+            fi
+        done
+    fi
+
+    # if everything else fails, use EL7
+    if [ "x$SELECTED_IMAGE" = "x" ]; then
+        if [ "x$CUDA_VISIBLE_DEVICES" != "x" -o "x$NVIDIA_VISIBLE_DEVICES" != "x" ]; then
+            SELECTED_IMAGE="opensciencegrid/osgvo-el7-cuda10:latest"
+        else
+            SELECTED_IMAGE="opensciencegrid/osgvo-el7:latest"
+        fi
+    fi
+
+    # Should we use CVMFS or pull images directly?
+
+    # Set image storage location via $IMAGES_DIR in the environment
+    # or IMAGES_DIR in the glidein config
+    [[ -n $IMAGES_DIR ]] || IMAGES_DIR=$(get_glidein_config_value IMAGES_DIR)
+    [[ -n $IMAGES_DIR ]] || IMAGES_DIR=$PWD
+    mkdir -p "$IMAGES_DIR"
+    (( disk_free=$(df -kP "$IMAGES_DIR" 2>/dev/null | awk '{if (NR==2) print $4}') ))
+    disk_free_gb=$(($disk_free / 1024 / 1024))
+    pull_images=-1
+    is_itb=$(get_glidein_config_value Is_ITB_Site)
+    entry_name=$(get_glidein_config_value GLIDEIN_Entry_Name)
+    singularity_can_use_sif=0
+    
+    # Make an images subdir and symlink to it from the pilot dir
+    # The subdir will contain the hostname so we can read the link to find out what host it's on
+    IMAGES_SUBDIR=$IMAGES_DIR/images-$(hostname)/
+    mkdir -p "$IMAGES_SUBDIR"
+    if ! echo x > "$IMAGES_SUBDIR/.test" 2>&1; then
+        info "Not allowing non-CVMFS images, as we couldn't write to the images dir ($IMAGES_SUBDIR)"
+        pull_images=0  # So close!
+    fi
+    rm -f "$IMAGES_SUBDIR/.test"
+    ln -snf "$IMAGES_SUBDIR" images
+
+    # the images dir is required here, as we want to keep a copy of the image for this test
+    if check_singularity_sif_support; then
+        singularity_can_use_sif=1
+    fi
+
+    if [[ $pull_images -ge 0 ]]; then
+        # decision already made
+        :
+    elif (uname -r | egrep '^3\.') >/dev/null 2>&1; then
+        # do not allow .sif images on 3.x kernels (OSPOOL-18)
+        pull_images=0
+    elif (echo "x$entry_name" | egrep "OSG_CHTC-canary2|Syracuse") >/dev/null 2>&1; then
+        info "Not allowing non-CVMFS images, as the site is on the deny list ($entry_name)"
+        pull_images=0
+    elif [ $singularity_can_use_sif = 0 ]; then
+        # Forbid running non-CVMFS images if they have to be unpacked first.
+        # May change later if we find sites where this is "safe."
+        info "Not allowing non-CVMFS images, as Singularity cannot directly run SIF files"
+        pull_images=0
+    elif [[ $disk_free_gb -lt 10 ]]; then
+        info "Not allowing non-CVMFS images, as the site does not have enough free disk space on the images volume ($disk_free_gb GBs)"
+        pull_images=0
+    elif [ "x$ALLOW_NONCVMFS_IMAGES" != "x" ]; then
+        info "Allowing non-CVMFS images because \$ALLOW_NONCVMFS_IMAGES is set"
+        pull_images=1
+    elif (echo "x$entry_name" | egrep "Clemson|ELSA|ODU-Ubuntu|Stampede2|UTC-Epyc") >/dev/null 2>&1; then
+        info "Allowing non-CVMFS images because of the entry name: $entry_name"
+        pull_images=1
+    elif ! (ls /cvmfs/singularity.opensciencegrid.org/) >/dev/null 2>&1; then
+        info "Allowing non-CVMFS images because /cvmfs/singularity.opensciencegrid.org/ is not available"
+        pull_images=1
+    fi
+    if [ $pull_images = 1 ]; then
+        # pull the image into a Singularity SIF file
+        IMAGE_NAME=$(echo "$SELECTED_IMAGE" | sed 's;[:/];__;g')
+        IMAGE_PATH=$PWD/images/$IMAGE_NAME.sif
+        URL=http://stash.osgconnect.net/public/rynge/infrastructure/images/sif/$IMAGE_NAME.sif
+        WEEK=$(date +'%V')
+        (stash_download $IMAGE_PATH stash:///osgconnect/public/rynge/infrastructure/images/$WEEK/sif/$IMAGE_NAME.sif \
+            || http_download $IMAGE_PATH $URL \
+            || singularity pull --force $IMAGE_PATH docker://hub.opensciencegrid.org/$SELECTED_IMAGE) >$IMAGE_PATH.log 2>&1
+        if [ $? = 0 ]; then
+            advertise ALLOW_NONCVMFS_IMAGES "True" "C"
+            advertise GWMS_SINGULARITY_PULL_IMAGES "True" "C"
+            advertise SINGULARITY_IMAGES_DICT "default:$IMAGE_PATH" "S"
+            advertise REQUIRED_OS "default" "S"
+            advertise OSG_DEFAULT_SINGULARITY_IMAGE "$IMAGE_PATH" "S"
+            return 0
+        else
+            my_warn "Failed to pull $SELECTED_IMAGE; falling back to CVMFS"
+        fi
+    fi
+
+    # prepend the base bath
+    SELECTED_IMAGE="/cvmfs/singularity.opensciencegrid.org/$SELECTED_IMAGE"
+    advertise SINGULARITY_IMAGES_DICT "default:$SELECTED_IMAGE" "S"
+    advertise OSG_DEFAULT_SINGULARITY_IMAGE "$SELECTED_IMAGE" "S"
+    advertise REQUIRED_OS "default" "S"
+}
+
+if [ "$glidein_config" != "NONE" ]; then
+    ###########################################################
+    # import advertise and add_condor_vars_line functions
+    if [ "x$add_config_line_source" = "x" ]; then
+        export add_config_line_source=`grep '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}'`
+        export condor_vars_file=`grep -i "^CONDOR_VARS_FILE " $glidein_config | awk '{print $2}'`
+    fi
+
+    # full path is problematic as sometimes we are inside a container - however, looks like
+    # the file is always named "add_config_line.source", so use that
+    add_config_line_source=$PWD/add_config_line.source
+
+    source $add_config_line_source
+
+    # XXX Patch over add_config_line() with a safer version
+    # This will be fixed in gWMS 3.9.6
+    add_config_line() {
+        # Ignore the call if the exact config line is already in there
+        if ! grep -q "^${*}$" "${glidein_config}"; then
+            # Use temporary files to make sure multiple add_config_line() calls don't clobber
+            # the glidein_config.
+            local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
+            local tmp_config1="${glidein_config}.$r.1"
+            local tmp_config2="${glidein_config}.$r.2"
+
+            # Copy the glidein config so it doesn't get modified while we grep out the old value
+            if ! cp -p "${glidein_config}" "${tmp_config1}"; then
+                warn "Error writing ${tmp_config1}"
+                rm -f "${tmp_config1}"
+                exit 1
+            fi
+            grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
+            rm -f "${tmp_config1}"
+            if [ ! -f "${tmp_config2}" ]; then
+                warn "Error creating ${tmp_config2}"
+                exit 1
+            fi
+            # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
+            echo "$@" >> "${tmp_config2}"
+
+            # Replace glidein config atomically
+            if ! mv -f "${tmp_config2}" "${glidein_config}"; then
+                warn "Error updating ${glidein_config} from ${tmp_config2}"
+                rm -f "${tmp_config2}"
+                exit 1
+            fi
+        fi
+    }
+    # XXX End add_config_line() patch
+fi
+
+# source our helpers
+group_dir=$(get_glidein_config_value GLIDECLIENT_GROUP_WORK_DIR)
+if [ -e "$group_dir/itb-ospool-lib" ]; then
+    source "$group_dir/itb-ospool-lib"
+else
+    source "$group_dir/ospool-lib"
+fi
+
+determine_default_container_image
+
+

--- a/ospool-pilot/old/pilot/singularity-extras
+++ b/ospool-pilot/old/pilot/singularity-extras
@@ -1,0 +1,128 @@
+#!/bin/bash
+#
+# This script is run *once* after the GWMS Singularity detection,
+# and can be used to do additional Singularity capability testing
+# and advertising.
+#
+
+glidein_config="$1"
+export glidein_config
+
+# make sure we do not put images in /tmp
+export TMPDIR="$PWD/tmp"
+mkdir -p $TMPDIR
+
+function info {
+    echo "INFO  " $@ 1>&2
+}
+
+function my_warn {
+    echo "WARN  " $@ 1>&2
+    export GLIDEIN_VALIDATION_WARNINGS="$@. $GLIDEIN_VALIDATION_WARNINGS"
+}
+
+function get_glidein_config_value {
+    # extracts a config attribute value from 
+    # $1 is the attribute key
+    CF=$glidein_config
+    if [ "$glidein_config" = "NONE" ]; then
+        CF="$PWD/glidein_config"
+    fi
+    KEY="$1"
+    VALUE=`(cat $CF | grep "^$KEY " | tail -n 1 | sed "s/^$KEY //") 2>/dev/null`
+    echo "$VALUE"
+}
+
+info "Determining extra Singularity capabilities..."
+
+if [ "$glidein_config" != "NONE" ]; then
+    ###########################################################
+    # import advertise and add_condor_vars_line functions
+    if [ "x$add_config_line_source" = "x" ]; then
+        export add_config_line_source=`grep '^ADD_CONFIG_LINE_SOURCE ' $glidein_config | awk '{print $2}'`
+        export condor_vars_file=`grep -i "^CONDOR_VARS_FILE " $glidein_config | awk '{print $2}'`
+    fi
+
+    info "Sourcing $add_config_line_source"
+    source $add_config_line_source
+
+    # XXX Patch over add_config_line() with a safer version
+    # This will be fixed in gWMS 3.9.6
+    add_config_line() {
+        # Ignore the call if the exact config line is already in there
+        if ! grep -q "^${*}$" "${glidein_config}"; then
+            # Use temporary files to make sure multiple add_config_line() calls don't clobber
+            # the glidein_config.
+            local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
+            local tmp_config1="${glidein_config}.$r.1"
+            local tmp_config2="${glidein_config}.$r.2"
+
+            # Copy the glidein config so it doesn't get modified while we grep out the old value
+            if ! cp -p "${glidein_config}" "${tmp_config1}"; then
+                warn "Error writing ${tmp_config1}"
+                rm -f "${tmp_config1}"
+                exit 1
+            fi
+            grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
+            rm -f "${tmp_config1}"
+            if [ ! -f "${tmp_config2}" ]; then
+                warn "Error creating ${tmp_config2}"
+                exit 1
+            fi
+            # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
+            echo "$@" >> "${tmp_config2}"
+
+            # Replace glidein config atomically
+            if ! mv -f "${tmp_config2}" "${glidein_config}"; then
+                warn "Error updating ${glidein_config} from ${tmp_config2}"
+                rm -f "${tmp_config2}"
+                exit 1
+            fi
+        fi
+    }
+    # XXX End add_config_line() patch
+fi
+
+# source our helpers
+group_dir=$(get_glidein_config_value GLIDECLIENT_GROUP_WORK_DIR)
+if [ -e "$group_dir/itb-ospool-lib" ]; then
+    source "$group_dir/itb-ospool-lib"
+else
+    source "$group_dir/ospool-lib"
+fi
+
+# make sure singularity can do overlay/underlay
+if ! check_singularity_overunderlay; then
+    # disable Singularity, and why
+    advertise HAS_SINGULARITY "False" "C"
+    advertise SINGULARITY_COMMENT "Disabled due broken overlay/underlay" "S"
+fi
+
+# provide overrides for some sites/situations
+check_singularity_overrides
+
+# can the provided Singularity run .sif images?
+if check_singularity_sif_support; then
+    # make sure this goes false if we later figure out that
+    # singularity is not working correctly
+    advertise SINGULARITY_CAN_USE_SIF "HAS_SINGULARITY && STASHCP_VERIFIED" "C"
+    # can the provided Singularity run registry images?
+    # Pulling from docker:// URLs requires creating a SIF first which is done in the tempdir and is cached in the cachedir
+    if check_singularity_registry_support; then
+        advertise SINGULARITY_CAN_USE_REGISTRY "SINGULARITY_CAN_USE_SIF && SINGULARITY_DISK_IS_FULL =!= True" "C"
+    else
+        advertise SINGULARITY_CAN_USE_REGISTRY "False" "C"
+    fi
+else
+    advertise SINGULARITY_CAN_USE_SIF "False" "C"
+    advertise SINGULARITY_CAN_USE_REGISTRY "False" "C"
+fi
+
+
+clause1='(SINGULARITY_CAN_USE_REGISTRY || !(substr(TARGET.SingularityImage, 0, 9) == "docker://"))'
+clause2='(SINGULARITY_CAN_USE_SIF || !(substr(TARGET.SingularityImage, -4) == ".sif"))'
+advertise SINGULARITY_START_CLAUSE "(!isString(TARGET.SingularityImage) || ( $clause1 && $clause2 ))"  "C"
+
+# Tell HTCondor the path to the Singularity binary; this is a config option not an atribute
+# $F(GWMS_SINGULARITY_PATH) will cause it to update if GWMS_SINGULARITY_PATH is updated
+add_condor_vars_line SINGULARITY C '\\$F\\(GWMS_SINGULARITY_PATH\\)' "+" "N" "N" "-"


### PR DESCRIPTION
this will allow us to merge the job-hook stuff into main without impacting either frontend groups other than 'main' and 'gpu', or others' frontends that use our scripts.