### PR TITLE
SOFTWARE-4803: Move from static config of OSPool attribute, to runtime

### DIFF
--- a/ospool-pilot/itb-canary/pilot/advertise-base
+++ b/ospool-pilot/itb-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=686
+OSG_GLIDEIN_VERSION=687
 #######################################################################
 
 
@@ -250,6 +250,28 @@ if [ "x$TIMEOUT" != "x" ]; then
 fi
 
 advertise OSG_GLIDEIN_VERSION $OSG_GLIDEIN_VERSION "I"
+
+# OSPool - this attribute should _only_ be set to True if
+# the EP is registering to the production OSPool CMs, and
+# it is a generally availalbe EP for fairshare (that is,
+# no project or other START restrictions)
+GLIDEIN_Collector=$(get_glidein_config_value GLIDEIN_Collector)
+GLIDECLIENT_Group=$(get_glidein_config_value GLIDECLIENT_Group)
+GLIDEIN_Start_Extra=$(get_glidein_config_value GLIDEIN_Start_Extra)
+OSG_PROJECT_NAME=$(get_glidein_config_value OSG_PROJECT_NAME)
+OSPool="False"
+if (echo "$GLIDEIN_Collector" | grep cm-1.ospool.osg-htc.org) >/dev/null 2>&1; then
+    if (echo "$GLIDECLIENT_Group" | grep -E '^(gpu|main|main-canary)$') >/dev/null 2>&1; then
+        # gwms - use the group as determining factor
+        OSPool="True"
+    elif [ "x$GLIDECLIENT_Group" = "xmain-container" ]; then
+        # container - need to check if there are extra start expressions
+        if [ "x$GLIDEIN_Start_Extra" = "x" -a "x$OSG_PROJECT_NAME" = "x" ]; then
+            OSPool="True"
+        fi
+    fi
+fi
+advertise OSPool "$OSPool" "C"
 
 # we need the "outside" kernel version to be able to steer
 # singularity jobs to kernel/glibcs which are not too old

--- a/ospool-pilot/itb-canary/pilot/advertise-base
+++ b/ospool-pilot/itb-canary/pilot/advertise-base
@@ -266,7 +266,7 @@ if (echo "$GLIDEIN_Collector" | grep cm-1.ospool.osg-htc.org) >/dev/null 2>&1; t
         OSPool="True"
     elif [ "x$GLIDECLIENT_Group" = "xmain-container" ]; then
         # container - need to check if there are extra start expressions
-        if [ "x$GLIDEIN_Start_Extra" = "x" -a "x$OSG_PROJECT_NAME" = "x" ]; then
+        if [ "x$GLIDEIN_Start_Extra" = "xTrue" -a "x$OSG_PROJECT_NAME" = "x" ]; then
             OSPool="True"
         fi
     fi

--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=686
+OSG_GLIDEIN_VERSION=687
 #######################################################################
 
 
@@ -250,6 +250,28 @@ if [ "x$TIMEOUT" != "x" ]; then
 fi
 
 advertise OSG_GLIDEIN_VERSION $OSG_GLIDEIN_VERSION "I"
+
+# OSPool - this attribute should _only_ be set to True if
+# the EP is registering to the production OSPool CMs, and
+# it is a generally availalbe EP for fairshare (that is,
+# no project or other START restrictions)
+GLIDEIN_Collector=$(get_glidein_config_value GLIDEIN_Collector)
+GLIDECLIENT_Group=$(get_glidein_config_value GLIDECLIENT_Group)
+GLIDEIN_Start_Extra=$(get_glidein_config_value GLIDEIN_Start_Extra)
+OSG_PROJECT_NAME=$(get_glidein_config_value OSG_PROJECT_NAME)
+OSPool="False"
+if (echo "$GLIDEIN_Collector" | grep cm-1.ospool.osg-htc.org) >/dev/null 2>&1; then
+    if (echo "$GLIDECLIENT_Group" | grep -E '^(gpu|main|main-canary)$') >/dev/null 2>&1; then
+        # gwms - use the group as determining factor
+        OSPool="True"
+    elif [ "x$GLIDECLIENT_Group" = "xmain-container" ]; then
+        # container - need to check if there are extra start expressions
+        if [ "x$GLIDEIN_Start_Extra" = "x" -a "x$OSG_PROJECT_NAME" = "x" ]; then
+            OSPool="True"
+        fi
+    fi
+fi
+advertise OSPool "$OSPool" "C"
 
 # we need the "outside" kernel version to be able to steer
 # singularity jobs to kernel/glibcs which are not too old

--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -266,7 +266,7 @@ if (echo "$GLIDEIN_Collector" | grep cm-1.ospool.osg-htc.org) >/dev/null 2>&1; t
         OSPool="True"
     elif [ "x$GLIDECLIENT_Group" = "xmain-container" ]; then
         # container - need to check if there are extra start expressions
-        if [ "x$GLIDEIN_Start_Extra" = "x" -a "x$OSG_PROJECT_NAME" = "x" ]; then
+        if [ "x$GLIDEIN_Start_Extra" = "xTrue" -a "x$OSG_PROJECT_NAME" = "x" ]; then
             OSPool="True"
         fi
     fi

--- a/ospool-pilot/main-canary/pilot/advertise-base
+++ b/ospool-pilot/main-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=686
+OSG_GLIDEIN_VERSION=687
 #######################################################################
 
 
@@ -250,6 +250,28 @@ if [ "x$TIMEOUT" != "x" ]; then
 fi
 
 advertise OSG_GLIDEIN_VERSION $OSG_GLIDEIN_VERSION "I"
+
+# OSPool - this attribute should _only_ be set to True if
+# the EP is registering to the production OSPool CMs, and
+# it is a generally availalbe EP for fairshare (that is,
+# no project or other START restrictions)
+GLIDEIN_Collector=$(get_glidein_config_value GLIDEIN_Collector)
+GLIDECLIENT_Group=$(get_glidein_config_value GLIDECLIENT_Group)
+GLIDEIN_Start_Extra=$(get_glidein_config_value GLIDEIN_Start_Extra)
+OSG_PROJECT_NAME=$(get_glidein_config_value OSG_PROJECT_NAME)
+OSPool="False"
+if (echo "$GLIDEIN_Collector" | grep cm-1.ospool.osg-htc.org) >/dev/null 2>&1; then
+    if (echo "$GLIDECLIENT_Group" | grep -E '^(gpu|main|main-canary)$') >/dev/null 2>&1; then
+        # gwms - use the group as determining factor
+        OSPool="True"
+    elif [ "x$GLIDECLIENT_Group" = "xmain-container" ]; then
+        # container - need to check if there are extra start expressions
+        if [ "x$GLIDEIN_Start_Extra" = "x" -a "x$OSG_PROJECT_NAME" = "x" ]; then
+            OSPool="True"
+        fi
+    fi
+fi
+advertise OSPool "$OSPool" "C"
 
 # we need the "outside" kernel version to be able to steer
 # singularity jobs to kernel/glibcs which are not too old

--- a/ospool-pilot/main-canary/pilot/advertise-base
+++ b/ospool-pilot/main-canary/pilot/advertise-base
@@ -266,7 +266,7 @@ if (echo "$GLIDEIN_Collector" | grep cm-1.ospool.osg-htc.org) >/dev/null 2>&1; t
         OSPool="True"
     elif [ "x$GLIDECLIENT_Group" = "xmain-container" ]; then
         # container - need to check if there are extra start expressions
-        if [ "x$GLIDEIN_Start_Extra" = "x" -a "x$OSG_PROJECT_NAME" = "x" ]; then
+        if [ "x$GLIDEIN_Start_Extra" = "xTrue" -a "x$OSG_PROJECT_NAME" = "x" ]; then
             OSPool="True"
         fi
     fi

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=658
+OSG_GLIDEIN_VERSION=659
 #######################################################################
 
 
@@ -250,6 +250,28 @@ if [ "x$TIMEOUT" != "x" ]; then
 fi
 
 advertise OSG_GLIDEIN_VERSION $OSG_GLIDEIN_VERSION "I"
+
+# OSPool - this attribute should _only_ be set to True if
+# the EP is registering to the production OSPool CMs, and
+# it is a generally availalbe EP for fairshare (that is,
+# no project or other START restrictions)
+GLIDEIN_Collector=$(get_glidein_config_value GLIDEIN_Collector)
+GLIDECLIENT_Group=$(get_glidein_config_value GLIDECLIENT_Group)
+GLIDEIN_Start_Extra=$(get_glidein_config_value GLIDEIN_Start_Extra)
+OSG_PROJECT_NAME=$(get_glidein_config_value OSG_PROJECT_NAME)
+OSPool="False"
+if (echo "$GLIDEIN_Collector" | grep cm-1.ospool.osg-htc.org) >/dev/null 2>&1; then
+    if (echo "$GLIDECLIENT_Group" | grep -E '^(gpu|main|main-canary)$') >/dev/null 2>&1; then
+        # gwms - use the group as determining factor
+        OSPool="True"
+    elif [ "x$GLIDECLIENT_Group" = "xmain-container" ]; then
+        # container - need to check if there are extra start expressions
+        if [ "x$GLIDEIN_Start_Extra" = "x" -a "x$OSG_PROJECT_NAME" = "x" ]; then
+            OSPool="True"
+        fi
+    fi
+fi
+advertise OSPool "$OSPool" "C"
 
 # we need the "outside" kernel version to be able to steer
 # singularity jobs to kernel/glibcs which are not too old

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -266,7 +266,7 @@ if (echo "$GLIDEIN_Collector" | grep cm-1.ospool.osg-htc.org) >/dev/null 2>&1; t
         OSPool="True"
     elif [ "x$GLIDECLIENT_Group" = "xmain-container" ]; then
         # container - need to check if there are extra start expressions
-        if [ "x$GLIDEIN_Start_Extra" = "x" -a "x$OSG_PROJECT_NAME" = "x" ]; then
+        if [ "x$GLIDEIN_Start_Extra" = "xTrue" -a "x$OSG_PROJECT_NAME" = "x" ]; then
             OSPool="True"
         fi
     fi

--- a/ospool.osg-htc.org/production/frontend-template.xml
+++ b/ospool.osg-htc.org/production/frontend-template.xml
@@ -208,7 +208,6 @@
             </credentials>
          </security>
          <attrs>
-            <attr name="OSPool" glidein_publish="True" job_publish="False" parameter="True" type="expr" value="True"/>
             <attr name="GLIDECLIENT_OSG_VO" glidein_publish="True" job_publish="True" parameter="False" type="string" value="OSG"/>
             <attr name="GLIDEIN_GPUS" glidein_publish="True" job_publish="True" parameter="True" type="int" value="1"/>
             <attr name="GLIDEIN_Glexec_Use" glidein_publish="True" job_publish="True" parameter="True" type="string" value="NEVER"/>
@@ -279,7 +278,6 @@
             </credentials>
          </security>
          <attrs>
-            <attr name="OSPool" glidein_publish="True" job_publish="False" parameter="True" type="expr" value="True"/>
             <attr name="GLIDECLIENT_OSG_VO" glidein_publish="True" job_publish="True" parameter="False" type="string" value="OSG"/>
             <attr name="GLIDEIN_Glexec_Use" glidein_publish="True" job_publish="True" parameter="True" type="string" value="NEVER"/>
             <attr name="SLOTS_LAYOUT" glidein_publish="True" job_publish="True" parameter="False" type="string" value="partitionable"/>
@@ -349,7 +347,6 @@
             </credentials>
          </security>
          <attrs>
-            <attr name="OSPool" glidein_publish="True" job_publish="False" parameter="True" type="expr" value="True"/>
             <attr name="GLIDECLIENT_OSG_VO" glidein_publish="True" job_publish="True" parameter="False" type="string" value="OSG"/>
             <attr name="GLIDEIN_Glexec_Use" glidein_publish="True" job_publish="True" parameter="True" type="string" value="NEVER"/>
             <attr name="SLOTS_LAYOUT" glidein_publish="True" job_publish="True" parameter="False" type="string" value="partitionable"/>


### PR DESCRIPTION
The OSPool is now determined by examining the configs (collectors, glidein group, extra expressions). This will work across GWMS glideins and the osgvo-docker-pilot (https://github.com/opensciencegrid/osgvo-docker-pilot/pull/126)