### PR TITLE
osg-flock RPM: add BuildRequires: condor

### DIFF
--- a/rpm/osg-flock.spec
+++ b/rpm/osg-flock.spec
@@ -1,6 +1,6 @@
 Name:      osg-flock
 Version:   1.9
-Release:   1%{?dist}
+Release:   2%{?dist}
 Summary:   OSG configurations for a flocking host
 
 License:   Apache 2.0
@@ -9,6 +9,7 @@ URL:       https://opensciencegrid.org/docs/submit/osg-flock
 BuildArch: noarch
 
 Requires(post): gratia-probe-condor-ap
+BuildRequires: condor
 Requires: condor
 
 Source0: %{name}-%{version}%{?gitrev:-%{gitrev}}.tar.gz


### PR DESCRIPTION
so we don't accidentally build it on a branch that doesn't have condor (3.6 main on el9)