### PR TITLE
Remove CMSSW integration

### DIFF
--- a/node-check/osgvo-node-advertise
+++ b/node-check/osgvo-node-advertise
@@ -871,34 +871,6 @@ if (cat /stash/user/test.osgconnect.1M) >/dev/null 2>&1; then
 fi
 
 ##################
-# cms software
-
-info "Checking for CMS software..."
-OSGVO_CMSSW_Path=""
-if [ -r "$OSG_APP/cmssoft/cms/cmsset_default.sh" ]
-then
-    OSGVO_CMSSW_Path="$OSG_APP/cmssoft/cms/"
-elif [ -r $VO_CMS_SW_DIR/cmsset_default.sh ]
-then
-    OSGVO_CMSSW_Path="$VO_CMS_SW_DIR/"
-fi
-if [ "x$OSGVO_CMSSW_Path" != "x" ]
-then
-    advertise OSGVO_CMSSW_Path "$OSGVO_CMSSW_Path" "S"
-fi
-
-OSGVO_CMSSW_Revision=""
-if [ "x$OSGVO_CMSSW_Path" != "x" -a -r "$OSGVO_CMSSW_Path/etc/cms-common/revision" ]
-then
-    OSGVO_CMSSW_Revision=$(head -c 10 "$OSGVO_CMSSW_Path/etc/cms-common/revision")
-fi
-if [ "x$OSGVO_CMSSW_Revision" != "x" ]
-then
-    advertise OSGVO_CMSSW_Revision "$OSGVO_CMSSW_Revision - $OSGVO_CMSSW_Path/etc/cms-common/revision" "S"
-fi
-
-
-##################
 # tcsh test
 
 info "Attempting to determine if tcsh is available and works..."

--- a/ospool-pilot/itb/pilot/advertise-userenv
+++ b/ospool-pilot/itb/pilot/advertise-userenv
@@ -316,33 +316,6 @@ else
     advertise STASHCP_VERIFIED "False" "C"
 fi
 
-##################
-# cms software
-
-info "Checking for CMS software..."
-OSGVO_CMSSW_Path=""
-if [ -r "$OSG_APP/cmssoft/cms/cmsset_default.sh" ]
-then
-    OSGVO_CMSSW_Path="$OSG_APP/cmssoft/cms/"
-elif [ -r $VO_CMS_SW_DIR/cmsset_default.sh ]
-then
-    OSGVO_CMSSW_Path="$VO_CMS_SW_DIR/"
-fi
-if [ "x$OSGVO_CMSSW_Path" != "x" ]
-then
-    advertise OSGVO_CMSSW_Path "$OSGVO_CMSSW_Path" "S"
-fi
-
-OSGVO_CMSSW_Revision=""
-if [ "x$OSGVO_CMSSW_Path" != "x" -a -r "$OSGVO_CMSSW_Path/etc/cms-common/revision" ]
-then
-    OSGVO_CMSSW_Revision=$(head -c 10 "$OSGVO_CMSSW_Path/etc/cms-common/revision")
-fi
-if [ "x$OSGVO_CMSSW_Revision" != "x" ]
-then
-    advertise OSGVO_CMSSW_Revision "$OSGVO_CMSSW_Revision - $OSGVO_CMSSW_Path/etc/cms-common/revision" "S"
-fi
-
 
 # modules
 RESULT="False"

--- a/ospool-pilot/main-canary/pilot/advertise-userenv
+++ b/ospool-pilot/main-canary/pilot/advertise-userenv
@@ -316,34 +316,6 @@ else
     advertise STASHCP_VERIFIED "False" "C"
 fi
 
-##################
-# cms software
-
-info "Checking for CMS software..."
-OSGVO_CMSSW_Path=""
-if [ -r "$OSG_APP/cmssoft/cms/cmsset_default.sh" ]
-then
-    OSGVO_CMSSW_Path="$OSG_APP/cmssoft/cms/"
-elif [ -r $VO_CMS_SW_DIR/cmsset_default.sh ]
-then
-    OSGVO_CMSSW_Path="$VO_CMS_SW_DIR/"
-fi
-if [ "x$OSGVO_CMSSW_Path" != "x" ]
-then
-    advertise OSGVO_CMSSW_Path "$OSGVO_CMSSW_Path" "S"
-fi
-
-OSGVO_CMSSW_Revision=""
-if [ "x$OSGVO_CMSSW_Path" != "x" -a -r "$OSGVO_CMSSW_Path/etc/cms-common/revision" ]
-then
-    OSGVO_CMSSW_Revision=$(head -c 10 "$OSGVO_CMSSW_Path/etc/cms-common/revision")
-fi
-if [ "x$OSGVO_CMSSW_Revision" != "x" ]
-then
-    advertise OSGVO_CMSSW_Revision "$OSGVO_CMSSW_Revision - $OSGVO_CMSSW_Path/etc/cms-common/revision" "S"
-fi
-
-
 # modules
 RESULT="False"
 find . -maxdepth 1 -name $TEST_FILE_1H.modules -mmin +8 -exec rm {} \;

--- a/ospool-pilot/main/pilot/advertise-userenv
+++ b/ospool-pilot/main/pilot/advertise-userenv
@@ -316,33 +316,6 @@ else
     advertise STASHCP_VERIFIED "False" "C"
 fi
 
-##################
-# cms software
-
-info "Checking for CMS software..."
-OSGVO_CMSSW_Path=""
-if [ -r "$OSG_APP/cmssoft/cms/cmsset_default.sh" ]
-then
-    OSGVO_CMSSW_Path="$OSG_APP/cmssoft/cms/"
-elif [ -r $VO_CMS_SW_DIR/cmsset_default.sh ]
-then
-    OSGVO_CMSSW_Path="$VO_CMS_SW_DIR/"
-fi
-if [ "x$OSGVO_CMSSW_Path" != "x" ]
-then
-    advertise OSGVO_CMSSW_Path "$OSGVO_CMSSW_Path" "S"
-fi
-
-OSGVO_CMSSW_Revision=""
-if [ "x$OSGVO_CMSSW_Path" != "x" -a -r "$OSGVO_CMSSW_Path/etc/cms-common/revision" ]
-then
-    OSGVO_CMSSW_Revision=$(head -c 10 "$OSGVO_CMSSW_Path/etc/cms-common/revision")
-fi
-if [ "x$OSGVO_CMSSW_Revision" != "x" ]
-then
-    advertise OSGVO_CMSSW_Revision "$OSGVO_CMSSW_Revision - $OSGVO_CMSSW_Path/etc/cms-common/revision" "S"
-fi
-
 
 # modules
 RESULT="False"

--- a/ospool-pilot/old/pilot/advertise-userenv
+++ b/ospool-pilot/old/pilot/advertise-userenv
@@ -316,34 +316,6 @@ else
     advertise STASHCP_VERIFIED "False" "C"
 fi
 
-##################
-# cms software
-
-info "Checking for CMS software..."
-OSGVO_CMSSW_Path=""
-if [ -r "$OSG_APP/cmssoft/cms/cmsset_default.sh" ]
-then
-    OSGVO_CMSSW_Path="$OSG_APP/cmssoft/cms/"
-elif [ -r $VO_CMS_SW_DIR/cmsset_default.sh ]
-then
-    OSGVO_CMSSW_Path="$VO_CMS_SW_DIR/"
-fi
-if [ "x$OSGVO_CMSSW_Path" != "x" ]
-then
-    advertise OSGVO_CMSSW_Path "$OSGVO_CMSSW_Path" "S"
-fi
-
-OSGVO_CMSSW_Revision=""
-if [ "x$OSGVO_CMSSW_Path" != "x" -a -r "$OSGVO_CMSSW_Path/etc/cms-common/revision" ]
-then
-    OSGVO_CMSSW_Revision=$(head -c 10 "$OSGVO_CMSSW_Path/etc/cms-common/revision")
-fi
-if [ "x$OSGVO_CMSSW_Revision" != "x" ]
-then
-    advertise OSGVO_CMSSW_Revision "$OSGVO_CMSSW_Revision - $OSGVO_CMSSW_Path/etc/cms-common/revision" "S"
-fi
-
-
 # modules
 RESULT="False"
 find . -maxdepth 1 -name $TEST_FILE_1H.modules -mmin +8 -exec rm {} \;

--- a/wip-node-check/osgvo-advertise-userenv
+++ b/wip-node-check/osgvo-advertise-userenv
@@ -315,33 +315,6 @@ else
     advertise STASHCP_VERIFIED "False" "C"
 fi
 
-##################
-# cms software
-
-info "Checking for CMS software..."
-OSGVO_CMSSW_Path=""
-if [ -r "$OSG_APP/cmssoft/cms/cmsset_default.sh" ]
-then
-    OSGVO_CMSSW_Path="$OSG_APP/cmssoft/cms/"
-elif [ -r $VO_CMS_SW_DIR/cmsset_default.sh ]
-then
-    OSGVO_CMSSW_Path="$VO_CMS_SW_DIR/"
-fi
-if [ "x$OSGVO_CMSSW_Path" != "x" ]
-then
-    advertise OSGVO_CMSSW_Path "$OSGVO_CMSSW_Path" "S"
-fi
-
-OSGVO_CMSSW_Revision=""
-if [ "x$OSGVO_CMSSW_Path" != "x" -a -r "$OSGVO_CMSSW_Path/etc/cms-common/revision" ]
-then
-    OSGVO_CMSSW_Revision=$(head -c 10 "$OSGVO_CMSSW_Path/etc/cms-common/revision")
-fi
-if [ "x$OSGVO_CMSSW_Revision" != "x" ]
-then
-    advertise OSGVO_CMSSW_Revision "$OSGVO_CMSSW_Revision - $OSGVO_CMSSW_Path/etc/cms-common/revision" "S"
-fi
-
 
 # modules
 RESULT="False"


### PR DESCRIPTION
From the git history, it's not clear when this was introduced but we believe that all CMS users now have migrated out to CMS Connect. Judging by the code itself, this was quite ancient.