### PR TITLE
Moving sif fallback location to /osgconnect/public/osg/images

### DIFF
--- a/job-wrappers/itb-default_singularity_wrapper.sh
+++ b/job-wrappers/itb-default_singularity_wrapper.sh
@@ -186,7 +186,7 @@ download_or_build_singularity_image () {
             base_name=$(echo $singularity_image | sed 's;/cvmfs/singularity.opensciencegrid.org/;;' | sed 's;/*/$;;')
             image_name=$(echo "$base_name" | sed 's;[:/];__;g')
             week=$(date +'%V')
-            singularity_srcs="stash:///osgconnect/public/rynge/infrastructure/images/$week/sif/$image_name.sif https://data.isi.edu/osg/images/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
+            singularity_srcs="stash:///osgconnect/public/osg/images/$week/sif/$image_name.sif https://data.isi.edu/osg/images/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
         elif [[ -e "$singularity_image" ]]; then
             # the image is not on cvmfs, but has already been downloaded - short circuit here
             echo "$singularity_image"

--- a/ospool-pilot/itb-canary/job/prepare-hook
+++ b/ospool-pilot/itb-canary/job/prepare-hook
@@ -200,7 +200,7 @@ function download_or_build_singularity_image () {
             base_name=$(echo $singularity_image | sed 's;/cvmfs/singularity.opensciencegrid.org/;;' | sed 's;/*/$;;')
             image_name=$(echo "$base_name" | sed 's;[:/];__;g')
             week=$(date +'%V')
-            singularity_srcs="stash:///osgconnect/public/rynge/infrastructure/images/$week/sif/$image_name.sif http://stash.osgconnect.net/public/rynge/infrastructure/images/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
+            singularity_srcs="stash:///osgconnect/public/osg/images/$week/sif/$image_name.sif http://stash.osgconnect.net/public/osg/images/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
         elif [[ -e "$singularity_image" ]]; then
             # the image is not on cvmfs, but has already been downloaded - short circuit here
             echo "$singularity_image"

--- a/ospool-pilot/itb-canary/pilot/advertise-base
+++ b/ospool-pilot/itb-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=688
+OSG_GLIDEIN_VERSION=689
 #######################################################################
 
 

--- a/ospool-pilot/itb/job/prepare-hook
+++ b/ospool-pilot/itb/job/prepare-hook
@@ -200,7 +200,7 @@ function download_or_build_singularity_image () {
             base_name=$(echo $singularity_image | sed 's;/cvmfs/singularity.opensciencegrid.org/;;' | sed 's;/*/$;;')
             image_name=$(echo "$base_name" | sed 's;[:/];__;g')
             week=$(date +'%V')
-            singularity_srcs="stash:///osgconnect/public/rynge/infrastructure/images/$week/sif/$image_name.sif http://stash.osgconnect.net/public/rynge/infrastructure/images/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
+            singularity_srcs="stash:///osgconnect/public/osg/images/$week/sif/$image_name.sif http://stash.osgconnect.net/public/osg/images/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
         elif [[ -e "$singularity_image" ]]; then
             # the image is not on cvmfs, but has already been downloaded - short circuit here
             echo "$singularity_image"

--- a/ospool-pilot/itb/lib/ospool-lib
+++ b/ospool-pilot/itb/lib/ospool-lib
@@ -153,7 +153,7 @@ function check_singularity_sif_support {
 
     # Grab an alpine image from somewhere; ok to download each time since
     # it's like 3 megs
-    local cvmfs_alpine="/cvmfs/stash.osgstorage.org/osgconnect/public/rynge/infrastructure/images/static/library__alpine__latest.sif"
+    local cvmfs_alpine="/cvmfs/stash.osgstorage.org/osgconnect/public/osg/images/static/library__alpine__latest.sif"
     local static_registry_alpine="docker://ospool-static-registry.osg.chtc.io/alpine:latest"
     local sylabs_alpine="library://alpine:3"
     local work_dir=$(get_glidein_config_value GLIDEIN_WORK_DIR)

--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=688
+OSG_GLIDEIN_VERSION=689
 #######################################################################
 
 

--- a/ospool-pilot/itb/pilot/default-image
+++ b/ospool-pilot/itb/pilot/default-image
@@ -128,9 +128,9 @@ function determine_default_container_image {
         # pull the image into a Singularity SIF file
         IMAGE_NAME=$(echo "$SELECTED_IMAGE" | sed 's;[:/];__;g')
         IMAGE_PATH=$PWD/images/$IMAGE_NAME.sif
-        URL=http://stash.osgconnect.net/public/rynge/infrastructure/images/sif/$IMAGE_NAME.sif
+        URL=http://stash.osgconnect.net/public/osg/images/sif/$IMAGE_NAME.sif
         WEEK=$(date +'%V')
-        (stash_download $IMAGE_PATH stash:///osgconnect/public/rynge/infrastructure/images/$WEEK/sif/$IMAGE_NAME.sif \
+        (stash_download $IMAGE_PATH stash:///osgconnect/public/osg/images/$WEEK/sif/$IMAGE_NAME.sif \
             || http_download $IMAGE_PATH $URL \
             || singularity pull --force $IMAGE_PATH docker://hub.opensciencegrid.org/$SELECTED_IMAGE) >$IMAGE_PATH.log 2>&1
         if [ $? = 0 ]; then

--- a/ospool-pilot/main-canary/job/prepare-hook
+++ b/ospool-pilot/main-canary/job/prepare-hook
@@ -200,7 +200,7 @@ function download_or_build_singularity_image () {
             base_name=$(echo $singularity_image | sed 's;/cvmfs/singularity.opensciencegrid.org/;;' | sed 's;/*/$;;')
             image_name=$(echo "$base_name" | sed 's;[:/];__;g')
             week=$(date +'%V')
-            singularity_srcs="stash:///osgconnect/public/rynge/infrastructure/images/$week/sif/$image_name.sif http://stash.osgconnect.net/public/rynge/infrastructure/images/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
+            singularity_srcs="stash:///osgconnect/public/osg/images/$week/sif/$image_name.sif http://stash.osgconnect.net/public/osg/images/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
         elif [[ -e "$singularity_image" ]]; then
             # the image is not on cvmfs, but has already been downloaded - short circuit here
             echo "$singularity_image"

--- a/ospool-pilot/main-canary/pilot/advertise-base
+++ b/ospool-pilot/main-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=688
+OSG_GLIDEIN_VERSION=689
 #######################################################################
 
 

--- a/ospool-pilot/main/job/prepare-hook
+++ b/ospool-pilot/main/job/prepare-hook
@@ -200,7 +200,7 @@ function download_or_build_singularity_image () {
             base_name=$(echo $singularity_image | sed 's;/cvmfs/singularity.opensciencegrid.org/;;' | sed 's;/*/$;;')
             image_name=$(echo "$base_name" | sed 's;[:/];__;g')
             week=$(date +'%V')
-            singularity_srcs="stash:///osgconnect/public/rynge/infrastructure/images/$week/sif/$image_name.sif http://stash.osgconnect.net/public/rynge/infrastructure/images/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
+            singularity_srcs="stash:///osgconnect/public/osg/images/$week/sif/$image_name.sif http://stash.osgconnect.net/public/osg/images/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
         elif [[ -e "$singularity_image" ]]; then
             # the image is not on cvmfs, but has already been downloaded - short circuit here
             echo "$singularity_image"

--- a/ospool-pilot/main/lib/ospool-lib
+++ b/ospool-pilot/main/lib/ospool-lib
@@ -153,7 +153,7 @@ function check_singularity_sif_support {
 
     # Grab an alpine image from somewhere; ok to download each time since
     # it's like 3 megs
-    local cvmfs_alpine="/cvmfs/stash.osgstorage.org/osgconnect/public/rynge/infrastructure/images/static/library__alpine__latest.sif"
+    local cvmfs_alpine="/cvmfs/stash.osgstorage.org/osgconnect/public/osg/images/static/library__alpine__latest.sif"
     local static_registry_alpine="docker://ospool-static-registry.osg.chtc.io/alpine:latest"
     local sylabs_alpine="library://alpine:3"
     local work_dir=$(get_glidein_config_value GLIDEIN_WORK_DIR)

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=688
+OSG_GLIDEIN_VERSION=689
 #######################################################################
 
 

--- a/ospool-pilot/main/pilot/default-image
+++ b/ospool-pilot/main/pilot/default-image
@@ -128,9 +128,9 @@ function determine_default_container_image {
         # pull the image into a Singularity SIF file
         IMAGE_NAME=$(echo "$SELECTED_IMAGE" | sed 's;[:/];__;g')
         IMAGE_PATH=$PWD/images/$IMAGE_NAME.sif
-        URL=http://stash.osgconnect.net/public/rynge/infrastructure/images/sif/$IMAGE_NAME.sif
+        URL=http://stash.osgconnect.net/public/osg/images/sif/$IMAGE_NAME.sif
         WEEK=$(date +'%V')
-        (stash_download $IMAGE_PATH stash:///osgconnect/public/rynge/infrastructure/images/$WEEK/sif/$IMAGE_NAME.sif \
+        (stash_download $IMAGE_PATH stash:///osgconnect/public/osg/images/$WEEK/sif/$IMAGE_NAME.sif \
             || http_download $IMAGE_PATH $URL \
             || singularity pull --force $IMAGE_PATH docker://hub.opensciencegrid.org/$SELECTED_IMAGE) >$IMAGE_PATH.log 2>&1
         if [ $? = 0 ]; then

--- a/ospool-pilot/old/job/default_singularity_wrapper.sh
+++ b/ospool-pilot/old/job/default_singularity_wrapper.sh
@@ -186,7 +186,7 @@ download_or_build_singularity_image () {
             base_name=$(echo $singularity_image | sed 's;/cvmfs/singularity.opensciencegrid.org/;;' | sed 's;/*/$;;')
             image_name=$(echo "$base_name" | sed 's;[:/];__;g')
             week=$(date +'%V')
-            singularity_srcs="stash:///osgconnect/public/rynge/infrastructure/images/$week/sif/$image_name.sif http://stash.osgconnect.net/public/rynge/infrastructure/images/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
+            singularity_srcs="stash:///osgconnect/public/osg/images/$week/sif/$image_name.sif http://stash.osgconnect.net/public/osg/images/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
         elif [[ -e "$singularity_image" ]]; then
             # the image is not on cvmfs, but has already been downloaded - short circuit here
             echo "$singularity_image"

--- a/ospool-pilot/old/lib/ospool-lib
+++ b/ospool-pilot/old/lib/ospool-lib
@@ -153,7 +153,7 @@ function check_singularity_sif_support {
 
     # Grab an alpine image from somewhere; ok to download each time since
     # it's like 3 megs
-    local cvmfs_alpine="/cvmfs/stash.osgstorage.org/osgconnect/public/rynge/infrastructure/images/static/library__alpine__latest.sif"
+    local cvmfs_alpine="/cvmfs/stash.osgstorage.org/osgconnect/public/osg/images/static/library__alpine__latest.sif"
     local static_registry_alpine="docker://ospool-static-registry.osg.chtc.io/alpine:latest"
     local sylabs_alpine="library://alpine:3"
     local work_dir=$(get_glidein_config_value GLIDEIN_WORK_DIR)

--- a/ospool-pilot/old/pilot/advertise-base
+++ b/ospool-pilot/old/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=658
+OSG_GLIDEIN_VERSION=659
 #######################################################################
 
 

--- a/ospool-pilot/old/pilot/default-image
+++ b/ospool-pilot/old/pilot/default-image
@@ -128,9 +128,9 @@ function determine_default_container_image {
         # pull the image into a Singularity SIF file
         IMAGE_NAME=$(echo "$SELECTED_IMAGE" | sed 's;[:/];__;g')
         IMAGE_PATH=$PWD/images/$IMAGE_NAME.sif
-        URL=http://stash.osgconnect.net/public/rynge/infrastructure/images/sif/$IMAGE_NAME.sif
+        URL=http://stash.osgconnect.net/public/osg/images/sif/$IMAGE_NAME.sif
         WEEK=$(date +'%V')
-        (stash_download $IMAGE_PATH stash:///osgconnect/public/rynge/infrastructure/images/$WEEK/sif/$IMAGE_NAME.sif \
+        (stash_download $IMAGE_PATH stash:///osgconnect/public/osg/images/$WEEK/sif/$IMAGE_NAME.sif \
             || http_download $IMAGE_PATH $URL \
             || singularity pull --force $IMAGE_PATH docker://hub.opensciencegrid.org/$SELECTED_IMAGE) >$IMAGE_PATH.log 2>&1
         if [ $? = 0 ]; then

--- a/wip-job-wrappers/default_singularity_wrapper.sh
+++ b/wip-job-wrappers/default_singularity_wrapper.sh
@@ -186,7 +186,7 @@ download_or_build_singularity_image () {
             base_name=$(echo $singularity_image | sed 's;/cvmfs/singularity.opensciencegrid.org/;;' | sed 's;/*/$;;')
             image_name=$(echo "$base_name" | sed 's;[:/];__;g')
             week=$(date +'%V')
-            singularity_srcs="stash:///osgconnect/public/rynge/infrastructure/images/$week/sif/$image_name.sif https://data.isi.edu/osg/images/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
+            singularity_srcs="stash:///osgconnect/public/osg/images/$week/sif/$image_name.sif https://data.isi.edu/osg/images/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
         elif [[ -e "$singularity_image" ]]; then
             # the image is not on cvmfs, but has already been downloaded - short circuit here
             echo "$singularity_image"

--- a/wip-node-check/osgvo-default-image
+++ b/wip-node-check/osgvo-default-image
@@ -126,7 +126,7 @@ function determine_default_container_image {
         IMAGE_PATH=$PWD/images/$IMAGE_NAME.sif
         URL=http://data.isi.edu/osg/images/$IMAGE_NAME.sif
         WEEK=$(date +'%V')
-        (stash_download $IMAGE_PATH stash:///osgconnect/public/rynge/infrastructure/images/$WEEK/sif/$IMAGE_NAME.sif \
+        (stash_download $IMAGE_PATH stash:///osgconnect/public/osg/images/$WEEK/sif/$IMAGE_NAME.sif \
             || http_download $IMAGE_PATH $URL \
             || singularity pull --force $IMAGE_PATH docker://hub.opensciencegrid.org/$SELECTED_IMAGE) >$IMAGE_PATH.log 2>&1
         if [ $? = 0 ]; then

--- a/wip-node-check/ospool-lib
+++ b/wip-node-check/ospool-lib
@@ -123,7 +123,7 @@ function check_singularity_sif_support {
 
     # Grab an alpine image from somewhere; ok to download each time since
     # it's like 3 megs
-    local cvmfs_alpine="/cvmfs/stash.osgstorage.org/osgconnect/public/rynge/infrastructure/images/static/library__alpine__latest.sif"
+    local cvmfs_alpine="/cvmfs/stash.osgstorage.org/osgconnect/public/osg/images/static/library__alpine__latest.sif"
     local osghub_alpine="docker://hub.opensciencegrid.org/library/alpine:3"
     local sylabs_alpine="library://alpine:3"
     local work_dir=$(get_glidein_config_value GLIDEIN_WORK_DIR)


### PR DESCRIPTION
This was discussed in a meeting a couple of days ago. The goal is to move from the location under my user (`/osgconnect/public/rynge/infrastructure/`) to the `osg` generic location (`/osgconnect/public/osg/images`). I have updated the sif exporter to maintain the new location and it is ready to be used.