### PR TITLE
Removing desdm repo check

### DIFF
--- a/node-check/osgvo-node-advertise
+++ b/node-check/osgvo-node-advertise
@@ -355,7 +355,6 @@ if [ "x$OSG_SINGULARITY_REEXEC" = "x" ]; then
        atlas.cern.ch \
        cms.cern.ch \
        connect.opensciencegrid.org \
-       desdm.osgstorage.org \
        eic.opensciencegrid.org \
        gwosc.osgstorage.org \
        icecube.opensciencegrid.org \

--- a/ospool-pilot/itb-canary/pilot/advertise-base
+++ b/ospool-pilot/itb-canary/pilot/advertise-base
@@ -388,7 +388,6 @@ for FS in \
    clicdp.cern.ch \
    cms.cern.ch \
    connect.opensciencegrid.org \
-   desdm.osgstorage.org \
    eic.opensciencegrid.org \
    gluex.osgstorage.org \
    gwosc.osgstorage.org \

--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -388,7 +388,6 @@ for FS in \
    clicdp.cern.ch \
    cms.cern.ch \
    connect.opensciencegrid.org \
-   desdm.osgstorage.org \
    eic.opensciencegrid.org \
    gluex.osgstorage.org \
    gwosc.osgstorage.org \

--- a/ospool-pilot/main-canary/pilot/advertise-base
+++ b/ospool-pilot/main-canary/pilot/advertise-base
@@ -388,7 +388,6 @@ for FS in \
    clicdp.cern.ch \
    cms.cern.ch \
    connect.opensciencegrid.org \
-   desdm.osgstorage.org \
    eic.opensciencegrid.org \
    gluex.osgstorage.org \
    gwosc.osgstorage.org \

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -388,7 +388,6 @@ for FS in \
    clicdp.cern.ch \
    cms.cern.ch \
    connect.opensciencegrid.org \
-   desdm.osgstorage.org \
    eic.opensciencegrid.org \
    gluex.osgstorage.org \
    gwosc.osgstorage.org \

--- a/ospool-pilot/old/pilot/advertise-base
+++ b/ospool-pilot/old/pilot/advertise-base
@@ -362,7 +362,6 @@ for FS in \
    clicdp.cern.ch \
    cms.cern.ch \
    connect.opensciencegrid.org \
-   desdm.osgstorage.org \
    eic.opensciencegrid.org \
    gluex.osgstorage.org \
    gwosc.osgstorage.org \

--- a/wip-node-check/osgvo-advertise-base
+++ b/wip-node-check/osgvo-advertise-base
@@ -351,7 +351,6 @@ for FS in \
    belle.cern.ch \
    cms.cern.ch \
    connect.opensciencegrid.org \
-   desdm.osgstorage.org \
    eic.opensciencegrid.org \
    gluex.osgstorage.org \
    gwosc.osgstorage.org \


### PR DESCRIPTION
desdm repo was removed in August 2022: https://github.com/opensciencegrid/topology/commit/afac9b24a49280c4f4d250e039dad1a71403ee16