### PR TITLE
Add /cvmfs/software.igwn.org check

### DIFF
--- a/node-check/osgvo-node-advertise
+++ b/node-check/osgvo-node-advertise
@@ -363,6 +363,7 @@ if [ "x$OSG_SINGULARITY_REEXEC" = "x" ]; then
        oasis.opensciencegrid.org \
        sft.cern.ch \
        singularity.opensciencegrid.org \
+       software.igwn.org \
        snoplus.egi.eu \
        sphenix.opensciencegrid.org \
        spt.opensciencegrid.org \

--- a/ospool-pilot/itb-canary/pilot/advertise-base
+++ b/ospool-pilot/itb-canary/pilot/advertise-base
@@ -403,6 +403,7 @@ for FS in \
    sft.cern.ch \
    singularity.opensciencegrid.org \
    snoplus.egi.eu \
+   software.igwn.org \
    sphenix.opensciencegrid.org \
    spt.opensciencegrid.org \
    stash.osgstorage.org \

--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -403,6 +403,7 @@ for FS in \
    sft.cern.ch \
    singularity.opensciencegrid.org \
    snoplus.egi.eu \
+   software.igwn.org \
    sphenix.opensciencegrid.org \
    spt.opensciencegrid.org \
    stash.osgstorage.org \

--- a/ospool-pilot/main-canary/pilot/advertise-base
+++ b/ospool-pilot/main-canary/pilot/advertise-base
@@ -403,6 +403,7 @@ for FS in \
    sft.cern.ch \
    singularity.opensciencegrid.org \
    snoplus.egi.eu \
+   software.igwn.org \
    sphenix.opensciencegrid.org \
    spt.opensciencegrid.org \
    stash.osgstorage.org \

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -403,6 +403,7 @@ for FS in \
    sft.cern.ch \
    singularity.opensciencegrid.org \
    snoplus.egi.eu \
+   software.igwn.org \
    sphenix.opensciencegrid.org \
    spt.opensciencegrid.org \
    stash.osgstorage.org \

--- a/ospool-pilot/old/pilot/advertise-base
+++ b/ospool-pilot/old/pilot/advertise-base
@@ -374,6 +374,7 @@ for FS in \
    sft.cern.ch \
    singularity.opensciencegrid.org \
    snoplus.egi.eu \
+   software.igwn.org \
    sphenix.opensciencegrid.org \
    spt.opensciencegrid.org \
    stash.osgstorage.org \

--- a/wip-node-check/osgvo-advertise-base
+++ b/wip-node-check/osgvo-advertise-base
@@ -363,6 +363,7 @@ for FS in \
    sft.cern.ch \
    singularity.opensciencegrid.org \
    snoplus.egi.eu \
+   software.igwn.org \
    sphenix.opensciencegrid.org \
    spt.opensciencegrid.org \
    stash.osgstorage.org \


### PR DESCRIPTION
This PR adds `software.igwn.org` to the list of CVMFS repositories that are checked for pilots.

I'm not really sure if this is the appropriate set of changes, I just reverse engineered af00ea1d48a0bea1c03661daeae255315e445e35.

Addresses https://github.com/lscsoft/osg-igwn/issues/511.