### PR TITLE
Use new OSDF/http targets for downloading images on non CVMFS sites

### DIFF
--- a/ospool-pilot/itb-canary/job/prepare-hook
+++ b/ospool-pilot/itb-canary/job/prepare-hook
@@ -200,7 +200,7 @@ function download_or_build_singularity_image () {
             base_name=$(echo $singularity_image | sed 's;/cvmfs/singularity.opensciencegrid.org/;;' | sed 's;/*/$;;')
             image_name=$(echo "$base_name" | sed 's;[:/];__;g')
             week=$(date +'%V')
-            singularity_srcs="osdf:///ospool/uc-shared/public/OSG-Staff/images/$week/sif/$image_name.sif http://ospool-images.osgdev.tempest.chtc.io/$week/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
+            singularity_srcs="osdf:///ospool/uc-shared/public/OSG-Staff/images/$week/sif/$image_name.sif http://ospool-images.osgprod.tempest.chtc.io/$week/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
         elif [[ -e "$singularity_image" ]]; then
             # the image is not on cvmfs, but has already been downloaded - short circuit here
             echo "$singularity_image"

--- a/ospool-pilot/itb-canary/pilot/advertise-base
+++ b/ospool-pilot/itb-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=703
+OSG_GLIDEIN_VERSION=704
 #######################################################################
 
 

--- a/ospool-pilot/itb/job/prepare-hook
+++ b/ospool-pilot/itb/job/prepare-hook
@@ -200,7 +200,7 @@ function download_or_build_singularity_image () {
             base_name=$(echo $singularity_image | sed 's;/cvmfs/singularity.opensciencegrid.org/;;' | sed 's;/*/$;;')
             image_name=$(echo "$base_name" | sed 's;[:/];__;g')
             week=$(date +'%V')
-            singularity_srcs="osdf:///ospool/uc-shared/public/OSG-Staff/images/$week/sif/$image_name.sif http://ospool-images.osgdev.tempest.chtc.io/$week/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
+            singularity_srcs="osdf:///ospool/uc-shared/public/OSG-Staff/images/$week/sif/$image_name.sif http://ospool-images.osgprod.tempest.chtc.io/$week/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
         elif [[ -e "$singularity_image" ]]; then
             # the image is not on cvmfs, but has already been downloaded - short circuit here
             echo "$singularity_image"

--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=694
+OSG_GLIDEIN_VERSION=695
 #######################################################################
 
 

--- a/ospool-pilot/itb/pilot/default-image
+++ b/ospool-pilot/itb/pilot/default-image
@@ -130,7 +130,7 @@ function determine_default_container_image {
         IMAGE_PATH=$PWD/images/$IMAGE_NAME.sif
         WEEK=$(date +'%V')
         OSDF_URL=osdf:///ospool/uc-shared/public/OSG-Staff/images/$WEEK/sif/$IMAGE_NAME.sif
-        HTTP_URL=http://ospool-images.osgdev.tempest.chtc.io/$WEEK/sif/$IMAGE_NAME.sif
+        HTTP_URL=http://ospool-images.osgprod.tempest.chtc.io/$WEEK/sif/$IMAGE_NAME.sif
         (osdf_download $IMAGE_PATH $OSDF_URL \
             || http_download $IMAGE_PATH $HTTP_URL \
             || singularity pull --force $IMAGE_PATH docker://hub.opensciencegrid.org/$SELECTED_IMAGE) >$IMAGE_PATH.log 2>&1

--- a/ospool-pilot/main-canary/job/prepare-hook
+++ b/ospool-pilot/main-canary/job/prepare-hook
@@ -200,7 +200,7 @@ function download_or_build_singularity_image () {
             base_name=$(echo $singularity_image | sed 's;/cvmfs/singularity.opensciencegrid.org/;;' | sed 's;/*/$;;')
             image_name=$(echo "$base_name" | sed 's;[:/];__;g')
             week=$(date +'%V')
-            singularity_srcs="stash:///osgconnect/public/osg/images/$week/sif/$image_name.sif http://stash.osgconnect.net/public/osg/images/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
+            singularity_srcs="osdf:///ospool/uc-shared/public/OSG-Staff/images/$week/sif/$image_name.sif http://ospool-images.osgprod.tempest.chtc.io/$week/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
         elif [[ -e "$singularity_image" ]]; then
             # the image is not on cvmfs, but has already been downloaded - short circuit here
             echo "$singularity_image"
@@ -263,7 +263,7 @@ function download_or_build_singularity_image () {
                 echo "Trying to download from $src ..." &>>$logfile
 
                 if (echo "$src" | grep -E "^(stash|osdf)://")>/dev/null 2>&1; then
-                    if (stash_download "$tmptarget2" "$src") &>>$logfile; then
+                    if (osdf_download "$tmptarget2" "$src") &>>$logfile; then
                         downloaded=1
                         break
                     fi

--- a/ospool-pilot/main-canary/pilot/advertise-base
+++ b/ospool-pilot/main-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=694
+OSG_GLIDEIN_VERSION=695
 #######################################################################
 
 

--- a/ospool-pilot/main/job/prepare-hook
+++ b/ospool-pilot/main/job/prepare-hook
@@ -200,7 +200,7 @@ function download_or_build_singularity_image () {
             base_name=$(echo $singularity_image | sed 's;/cvmfs/singularity.opensciencegrid.org/;;' | sed 's;/*/$;;')
             image_name=$(echo "$base_name" | sed 's;[:/];__;g')
             week=$(date +'%V')
-            singularity_srcs="stash:///osgconnect/public/osg/images/$week/sif/$image_name.sif http://stash.osgconnect.net/public/osg/images/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
+            singularity_srcs="osdf:///ospool/uc-shared/public/OSG-Staff/images/$week/sif/$image_name.sif http://ospool-images.osgprod.tempest.chtc.io/$week/sif/$image_name.sif docker://hub.opensciencegrid.org/$base_name"
         elif [[ -e "$singularity_image" ]]; then
             # the image is not on cvmfs, but has already been downloaded - short circuit here
             echo "$singularity_image"
@@ -263,7 +263,7 @@ function download_or_build_singularity_image () {
                 echo "Trying to download from $src ..." &>>$logfile
 
                 if (echo "$src" | grep -E "^(stash|osdf)://")>/dev/null 2>&1; then
-                    if (stash_download "$tmptarget2" "$src") &>>$logfile; then
+                    if (osdf_download "$tmptarget2" "$src") &>>$logfile; then
                         downloaded=1
                         break
                     fi

--- a/ospool-pilot/main/lib/ospool-lib
+++ b/ospool-pilot/main/lib/ospool-lib
@@ -81,7 +81,7 @@ function check_singularity_overrides {
     fi
 }
 
-function stash_download {
+function osdf_download {
     # Use stashcp to download a sif file; if the destination does not end in .sif, unpack the sif into the sandbox format
     local dest="$1"
     local src="$2"

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=694
+OSG_GLIDEIN_VERSION=695
 #######################################################################
 
 

--- a/ospool-pilot/main/pilot/default-image
+++ b/ospool-pilot/main/pilot/default-image
@@ -128,10 +128,11 @@ function determine_default_container_image {
         # pull the image into a Singularity SIF file
         IMAGE_NAME=$(echo "$SELECTED_IMAGE" | sed 's;[:/];__;g')
         IMAGE_PATH=$PWD/images/$IMAGE_NAME.sif
-        URL=http://stash.osgconnect.net/public/osg/images/sif/$IMAGE_NAME.sif
         WEEK=$(date +'%V')
-        (stash_download $IMAGE_PATH stash:///osgconnect/public/osg/images/$WEEK/sif/$IMAGE_NAME.sif \
-            || http_download $IMAGE_PATH $URL \
+        OSDF_URL=osdf:///ospool/uc-shared/public/OSG-Staff/images/$WEEK/sif/$IMAGE_NAME.sif
+        HTTP_URL=http://ospool-images.osgprod.tempest.chtc.io/$WEEK/sif/$IMAGE_NAME.sif
+        (osdf_download $IMAGE_PATH $OSDF_URL \
+            || http_download $IMAGE_PATH $HTTP_URL \
             || singularity pull --force $IMAGE_PATH docker://hub.opensciencegrid.org/$SELECTED_IMAGE) >$IMAGE_PATH.log 2>&1
         if [ $? = 0 ]; then
             advertise ALLOW_NONCVMFS_IMAGES "True" "C"


### PR DESCRIPTION
Need to get this is in place for the August 1st deadline. It takes time for the glideins to cycle through.

The OSDF endpoint is still not working, but the http fallback will handle things until that is fixed.