### PR TITLE
itb 697, itb-canary 710: advertise HAS_PYTHON3 and PYTHON3_VERSION

### DIFF
--- a/ospool-pilot/itb-canary/pilot/advertise-base
+++ b/ospool-pilot/itb-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=709
+OSG_GLIDEIN_VERSION=710
 #######################################################################
 
 

--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=696
+OSG_GLIDEIN_VERSION=697
 #######################################################################
 
 

--- a/ospool-pilot/itb/pilot/advertise-userenv
+++ b/ospool-pilot/itb/pilot/advertise-userenv
@@ -480,6 +480,13 @@ if python --version >/dev/null 2>&1; then
     fi
     advertise HAS_PYTHON "True" "C"
 fi
+if python3 --version >/dev/null 2>&1; then
+    PYTHON3_VERSION=`python3 --version 2>&1 | sed 's/Python //'`
+    if [ "x$PYTHON3_VERSION" != "x" ]; then
+        advertise PYTHON3_VERSION "$PYTHON3_VERSION" "S"
+    fi
+    advertise HAS_PYTHON3 "True" "C"
+fi
 
 info "Checking for numpy/scipy availability..."
 cat >py.check <<EOF
@@ -492,6 +499,8 @@ EOF
 
 Has_Numpy_Scipy="False"
 if python py.check >/dev/null 2>&1; then
+    Has_Numpy_Scipy="True"
+elif python3 py.check >/dev/null 2>&1; then
     Has_Numpy_Scipy="True"
 fi
 advertise HAS_NUMPY "$Has_Numpy_Scipy" "C"


### PR DESCRIPTION
Several distros no longer have a functional binary named "python" but do have a "python3". Check for that separately.