### PR TITLE
Remove kagra.storage.igwn.org from CVMFS repo check

### DIFF
--- a/node-check/osgvo-node-advertise
+++ b/node-check/osgvo-node-advertise
@@ -359,7 +359,6 @@ if [ "x$OSG_SINGULARITY_REEXEC" = "x" ]; then
        gwosc.osgstorage.org \
        icecube.opensciencegrid.org \
        icecube.osgstorage.org \
-       kagra.storage.igwn.org \
        ligo.storage.igwn.org \
        nexo.opensciencegrid.org \
        oasis.opensciencegrid.org \

--- a/ospool-pilot/itb-canary/pilot/advertise-base
+++ b/ospool-pilot/itb-canary/pilot/advertise-base
@@ -410,7 +410,6 @@ for FS in \
    gwosc.osgstorage.org \
    icecube.opensciencegrid.org \
    icecube.osgstorage.org \
-   kagra.storage.igwn.org \
    larsoft-ib.opensciencegrid.org \
    larsoft.opensciencegrid.org \
    ligo.storage.igwn.org \

--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -410,7 +410,6 @@ for FS in \
    gwosc.osgstorage.org \
    icecube.opensciencegrid.org \
    icecube.osgstorage.org \
-   kagra.storage.igwn.org \
    larsoft-ib.opensciencegrid.org \
    larsoft.opensciencegrid.org \
    ligo.storage.igwn.org \

--- a/ospool-pilot/main-canary/pilot/advertise-base
+++ b/ospool-pilot/main-canary/pilot/advertise-base
@@ -410,7 +410,6 @@ for FS in \
    gwosc.osgstorage.org \
    icecube.opensciencegrid.org \
    icecube.osgstorage.org \
-   kagra.storage.igwn.org \
    larsoft-ib.opensciencegrid.org \
    larsoft.opensciencegrid.org \
    ligo.storage.igwn.org \

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -410,7 +410,6 @@ for FS in \
    gwosc.osgstorage.org \
    icecube.opensciencegrid.org \
    icecube.osgstorage.org \
-   kagra.storage.igwn.org \
    larsoft-ib.opensciencegrid.org \
    larsoft.opensciencegrid.org \
    ligo.storage.igwn.org \

--- a/ospool-pilot/old/pilot/advertise-base
+++ b/ospool-pilot/old/pilot/advertise-base
@@ -367,7 +367,6 @@ for FS in \
    gwosc.osgstorage.org \
    icecube.opensciencegrid.org \
    icecube.osgstorage.org \
-   kagra.storage.igwn.org \
    larsoft-ib.opensciencegrid.org \
    larsoft.opensciencegrid.org \
    ligo.storage.igwn.org \

--- a/wip-node-check/osgvo-advertise-base
+++ b/wip-node-check/osgvo-advertise-base
@@ -356,7 +356,6 @@ for FS in \
    gwosc.osgstorage.org \
    icecube.opensciencegrid.org \
    icecube.osgstorage.org \
-   kagra.storage.igwn.org \
    larsoft-ib.opensciencegrid.org \
    larsoft.opensciencegrid.org \
    ligo.storage.igwn.org \


### PR DESCRIPTION
This PR removes `kagra.storage.igwn.org` from the list of CVMFS repos to check for in pilots; the repo doesn't exist yet, so is just adding noise.

Closes https://github.com/lscsoft/osg-igwn/issues/533.