### PR TITLE
Revert "Adjusting mem/disk oversubscription limits"

### DIFF
--- a/ospool.osg-htc.org/production/frontend-template.xml
+++ b/ospool.osg-htc.org/production/frontend-template.xml
@@ -51,8 +51,7 @@
                       ((DESIRED_Sites=?=undefined) || stringListMember(GLIDEIN_Site,DESIRED_Sites,",")) &amp;&amp;
                       ((UNDESIRED_Sites=?=undefined) || !stringListMember(GLIDEIN_Site,UNDESIRED_Sites,",")) &amp;&amp;
                       (isUndefined(TARGET.ProjectName) != True &amp;&amp; TARGET.ProjectName != "") &amp;&amp;
-                      (TARGET.RequestMemory &lt; (TARGET.RequestCPUs * 8 * MY.TotalSlotMemory / MY.TotalSlotCpus)) &amp;&amp;
-                      (TARGET.RequestDisk &lt; (TARGET.RequestCPUs * 8 * MY.TotalSlotDisk / MY.TotalSlotCpus)) &amp;&amp;
+                      (TARGET.RequestMemory &lt; (TARGET.RequestCPUs * 12 * MY.TotalSlotMemory / MY.TotalSlotCpus)) &amp;&amp;
                       (ifThenElse(JobDurationCategory =!= undefined &amp;&amp; JobDurationCategory == "Long", 
                                   GLIDEIN_ToDie - CurrentTime &gt;= 144000,
                                   GLIDEIN_Max_Walltime =?= undefined || GLIDEIN_Max_Walltime &lt; 43200 || GLIDEIN_ToDie - CurrentTime &gt;= 36000))


### PR DESCRIPTION
We currently suspect that this change is causing claim failures post-match
This reverts commit 7bb4a23cb0f5f0943c5e981bfbc2eed1a5bda791.