### PR TITLE
main, main-canary 727: Have the Pelican-based Stash/OSDF plugin and stashcp use the pre-7.5.0 behavior

### DIFF
--- a/ospool-pilot/main-canary/pilot/additional-htcondor-config
+++ b/ospool-pilot/main-canary/pilot/additional-htcondor-config
@@ -173,6 +173,14 @@ add_condor_vars_line CCB_HEARTBEAT_INTERVAL "C" "-" "+" "N" "N" "-"
 #add_condor_vars_line STARTER_DEBUG "C" "-" "+" "N" "N" "-"
 
 
+# Enable this to have the Pelican-based Stash/OSDF plugin and stashcp fall back
+# to the pre-7.5.0 behavior of using Topology instead of the director.
+# (STASH_USE_TOPOLOGY is blank or non-blank)
+export STASH_USE_TOPOLOGY=1
+add_config_line STASH_USE_TOPOLOGY "$STASH_USE_TOPOLOGY"
+add_condor_vars_line STASH_USE_TOPOLOGY "C" "-" "+" "N" "Y" "+"
+
+
 OSDF_FAIL_REASON=""
 OSDF_PLUGIN_VERSION=""
 osdf_plugin_is_ok () {

--- a/ospool-pilot/main-canary/pilot/advertise-base
+++ b/ospool-pilot/main-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=726
+OSG_GLIDEIN_VERSION=727
 #######################################################################
 
 

--- a/ospool-pilot/main/pilot/additional-htcondor-config
+++ b/ospool-pilot/main/pilot/additional-htcondor-config
@@ -173,6 +173,14 @@ add_condor_vars_line CCB_HEARTBEAT_INTERVAL "C" "-" "+" "N" "N" "-"
 #add_condor_vars_line STARTER_DEBUG "C" "-" "+" "N" "N" "-"
 
 
+# Enable this to have the Pelican-based Stash/OSDF plugin and stashcp fall back
+# to the pre-7.5.0 behavior of using Topology instead of the director.
+# (STASH_USE_TOPOLOGY is blank or non-blank)
+export STASH_USE_TOPOLOGY=1
+add_config_line STASH_USE_TOPOLOGY "$STASH_USE_TOPOLOGY"
+add_condor_vars_line STASH_USE_TOPOLOGY "C" "-" "+" "N" "Y" "+"
+
+
 OSDF_FAIL_REASON=""
 OSDF_PLUGIN_VERSION=""
 osdf_plugin_is_ok () {

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=726
+OSG_GLIDEIN_VERSION=727
 #######################################################################
 
 


### PR DESCRIPTION
We can turn this off as we feel more comfortable with the director, or back on if we discover that it's misbehaving.
