### PR TITLE
Revert "itb, itb-canary 732: put FT plugin logs into the StarterLog (OSPOOL-114)"

### DIFF
--- a/ospool-pilot/itb-canary/pilot/additional-htcondor-config
+++ b/ospool-pilot/itb-canary/pilot/additional-htcondor-config
@@ -302,13 +302,6 @@ if [[ ! $IS_CONTAINER_PILOT ]]; then
     [[ $DEBUG ]] && advertise "DEBUG" "$DEBUG" "S"
 fi  # ! $IS_CONTAINER_PILOT
 
-
-# Put FT plugin logs into the StarterLog (OSPOOL-114)
-set_condor_knob REDIRECT_FILETRANSFER_PLUGIN_STDERR_TO_STDOUT 'TRUE'
-set_condor_knob LOG_FILETRANSFER_PLUGIN_STDOUT_ON_SUCCESS 'D_ALWAYS'
-set_condor_knob LOG_FILETRANSFER_PLUGIN_STDOUT_ON_FAILURE 'D_ALWAYS'
-
-
 ##################################################################
 # Generate a minimal `STARTER_JOB_ENVIRONMENT`, mostly composed of
 # informational variables that are considered safe to always leak to

--- a/ospool-pilot/itb-canary/pilot/advertise-base
+++ b/ospool-pilot/itb-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=732
+OSG_GLIDEIN_VERSION=731
 #######################################################################
 
 

--- a/ospool-pilot/itb/pilot/additional-htcondor-config
+++ b/ospool-pilot/itb/pilot/additional-htcondor-config
@@ -302,13 +302,6 @@ if [[ ! $IS_CONTAINER_PILOT ]]; then
     [[ $DEBUG ]] && advertise "DEBUG" "$DEBUG" "S"
 fi  # ! $IS_CONTAINER_PILOT
 
-
-# Put FT plugin logs into the StarterLog (OSPOOL-114)
-set_condor_knob REDIRECT_FILETRANSFER_PLUGIN_STDERR_TO_STDOUT 'TRUE'
-set_condor_knob LOG_FILETRANSFER_PLUGIN_STDOUT_ON_SUCCESS 'D_ALWAYS'
-set_condor_knob LOG_FILETRANSFER_PLUGIN_STDOUT_ON_FAILURE 'D_ALWAYS'
-
-
 ##################################################################
 # Generate a minimal `STARTER_JOB_ENVIRONMENT`, mostly composed of
 # informational variables that are considered safe to always leak to

--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=732
+OSG_GLIDEIN_VERSION=731
 #######################################################################
 
 


### PR DESCRIPTION
Reverts opensciencegrid/osg-flock#263

This was causing my test job (with a failed transfer) to go on hold with no hold reason or hold reason code.