### PR TITLE
main, main-canary 741: merge changes from itb 741

### DIFF
--- a/ospool-pilot/main-canary/pilot/additional-htcondor-config
+++ b/ospool-pilot/main-canary/pilot/additional-htcondor-config
@@ -74,6 +74,13 @@ set_condor_knob () {
 
 condor_vars_file=`grep -i "^CONDOR_VARS_FILE " $glidein_config | awk '{print $2}'`
 
+# DEBUG will be advertised in the slot ad is nonempty; use add_to_debug() to add to it
+DEBUG=""
+add_to_debug () {
+    [[ $DEBUG ]] && DEBUG="${DEBUG}; "
+    DEBUG="${DEBUG}$(printf "%q " "$@")"
+}
+
 ###########################################################
 # CVMFS_BASE defaults to /cvmfs but can be overridden in case of for example cvmfsexec
 if [[ ! $CVMFS_BASE ]]; then
@@ -251,13 +258,18 @@ osdf_plugin_is_ok () {
 #       main/condor/condor-10.3.1-1-x86_64_CentOS7-stripped/usr
 # but by the time Condor starts up, it will have been moved to
 #       main/condor
-CONDOR_DIR=$(gconfig_get CONDOR_DIR)
 if [[ $IS_CONTAINER_PILOT ]]; then
+    CONDOR_DIR=/usr
     REAL_CONDOR_DIR=/usr
+    CONDOR_LIBEXEC=/usr/libexec/condor
+    REAL_CONDOR_LIBEXEC=/usr/libexec/condor
 else
+    CONDOR_DIR=$(gconfig_get CONDOR_DIR)
     # shellcheck disable=SC2086
     REAL_CONDOR_DIR=$(echo $CONDOR_DIR/condor-*/usr)
     # ^^ the "echo" is needed to expand the glob
+    CONDOR_LIBEXEC=$CONDOR_DIR/libexec
+    REAL_CONDOR_LIBEXEC=$REAL_CONDOR_DIR/libexec/condor
 fi
 
 # Get and parse condor version so we can add version-specific knobs.
@@ -290,93 +302,85 @@ fi
 #
 # If set to "condor", it will use what's in the Condor tarball.  (This can be
 # used to override a non-Condor default.)
-DEFAULT_DOWNLOAD_PELICAN_VERSION=7.6.1
+DEFAULT_DOWNLOAD_PELICAN_VERSION=7.6.2
 
 if [[ ! $DOWNLOAD_PELICAN_VERSION ]]; then
-    DOWNLOAD_PELICAN_VERSION=$DEFAULT_DOWNLOAD_PELICAN_VERSION
+    DOWNLOAD_PELICAN_VERSION=$(gconfig_get DOWNLOAD_PELICAN_VERSION)
+    if [[ ! $DOWNLOAD_PELICAN_VERSION ]]; then
+        DOWNLOAD_PELICAN_VERSION=$DEFAULT_DOWNLOAD_PELICAN_VERSION
+    fi
 fi
 
 
 ###########################################################
 # Test and add the stash/osdf plugin
 # It comes with condor, or we might be asked to download it.
-if [[ ! $IS_CONTAINER_PILOT ]]; then
-    # The container pilot has its own code for this (for now)
 
-    DEBUG=""
-    add_to_debug () {
-        [[ $DEBUG ]] && DEBUG="${DEBUG}; "
-        DEBUG="${DEBUG}$(printf "%q " "$@")"
-    }
+# Find the Stash/OSDF plugin; set OSDF_PLUGIN to its current location, and
+# set REAL_OSDF_PLUGIN to where it will be after glideinWMS has rearranged
+# the Condor install in the pilot.
+# The plugin will be tested later.
+if [[ $DOWNLOAD_PELICAN_VERSION && $DOWNLOAD_PELICAN_VERSION != condor ]]; then
+    # If this variable is set, and not set to "condor", download that
+    # version of Pelican and ignore the version from the HTCondor tarball.
 
-    CONDOR_LIBEXEC=$CONDOR_DIR/libexec
-    REAL_CONDOR_LIBEXEC=$REAL_CONDOR_DIR/libexec/condor
-
-    # add_to_debug "CONDOR_DIR=$CONDOR_DIR"
-    # add_to_debug "CONDOR_LIBEXEC=$CONDOR_LIBEXEC"
-    # add_to_debug "REAL_CONDOR_LIBEXEC=$REAL_CONDOR_LIBEXEC"
-
-    # Find the Stash/OSDF plugin; set OSDF_PLUGIN to its current location, and
-    # set REAL_OSDF_PLUGIN to where it will be after glideinWMS has rearranged
-    # the Condor install in the pilot.
-    # The plugin will be tested later.
-    if [[ $DOWNLOAD_PELICAN_VERSION && $DOWNLOAD_PELICAN_VERSION != condor ]]; then
-        # If this variable is set, and not set to "condor", download that
-        # version of Pelican and ignore the version from the HTCondor tarball.
-
-        arch=x86_64  # XXX add support for others (arm64, ppc64le)
-        url=https://github.com/PelicanPlatform/pelican/releases/download/v${DOWNLOAD_PELICAN_VERSION}/pelican_Linux_${arch}.tar.gz
-        _out=$( { 
-            curl -LSso pelican.tar.gz "$url" && 
-            tar -xzf pelican.tar.gz pelican &&
-            mv -f pelican stash_plugin &&
-            chmod +x stash_plugin
-        } 2>&1); ret=$?
-        if [[ $ret != 0 || ! -f stash_plugin || ! -x stash_plugin ]]; then
-            OSDF_FAIL_REASON="Couldn't download and install requested Pelican version ($DOWNLOAD_PELICAN_VERSION)"
-            add_to_debug "Pelican install output: $_out"
-        else
-            OSDF_PLUGIN=$(pwd -P)/stash_plugin
-            REAL_OSDF_PLUGIN=$(pwd -P)/stash_plugin
-            advertise "DOWNLOAD_PELICAN_VERSION" "$DOWNLOAD_PELICAN_VERSION" "S"
-        fi
+    url=https://github.com/PelicanPlatform/pelican/releases/download/v${DOWNLOAD_PELICAN_VERSION}/pelican_Linux_$(arch).tar.gz
+    _out=$( {
+        curl -LSso pelican.tar.gz "$url" &&
+        tar -xzf pelican.tar.gz pelican &&
+        mv -f pelican stash_plugin &&
+        chmod +x stash_plugin
+    } 2>&1); ret=$?
+    if [[ $ret != 0 || ! -f stash_plugin || ! -x stash_plugin ]]; then
+        OSDF_FAIL_REASON="Couldn't download and install requested Pelican version ($DOWNLOAD_PELICAN_VERSION)"
+        add_to_debug "Pelican install output: $_out"
     else
-        # Not asked to download a specific Pelican version, or specifically
-        # asked to use what's in the HTCondor tarball.
-        # Find the stash/osdf plugin in the HTCondor tarball.
-        if [[ -x $REAL_CONDOR_LIBEXEC/osdf_plugin ]]; then
-            # forward compat
-            OSDF_PLUGIN=$CONDOR_LIBEXEC/osdf_plugin
-            REAL_OSDF_PLUGIN=$REAL_CONDOR_LIBEXEC/osdf_plugin
-        elif [[ -x $REAL_CONDOR_LIBEXEC/stash_plugin ]]; then
-            OSDF_PLUGIN=$CONDOR_LIBEXEC/stash_plugin
-            REAL_OSDF_PLUGIN=$REAL_CONDOR_LIBEXEC/stash_plugin
-        else
-            OSDF_FAIL_REASON="Stash/OSDF plugin not found in pilot's condor install"
+        OSDF_PLUGIN=$(pwd -P)/stash_plugin
+        REAL_OSDF_PLUGIN=$(pwd -P)/stash_plugin
+        advertise "DOWNLOAD_PELICAN_VERSION" "$DOWNLOAD_PELICAN_VERSION" "S"
+    fi
+else
+    # Not asked to download a specific Pelican version, or specifically
+    # asked to use what's in the HTCondor tarball.
+    # Find the stash/osdf plugin in the HTCondor installation.
+    if [[ -x $REAL_CONDOR_LIBEXEC/osdf_plugin ]]; then
+        # forward compat
+        OSDF_PLUGIN=$CONDOR_LIBEXEC/osdf_plugin
+        REAL_OSDF_PLUGIN=$REAL_CONDOR_LIBEXEC/osdf_plugin
+    elif [[ -x $REAL_CONDOR_LIBEXEC/stash_plugin ]]; then
+        OSDF_PLUGIN=$CONDOR_LIBEXEC/stash_plugin
+        REAL_OSDF_PLUGIN=$REAL_CONDOR_LIBEXEC/stash_plugin
+    else
+        OSDF_FAIL_REASON="Stash/OSDF plugin not found in pilot's condor install"
+    fi
+fi
+
+# Test the stash/osdf plugin we found.
+if [[ $OSDF_PLUGIN ]]; then
+    # add_to_debug "Stash/OSDF plugin found at" "$REAL_OSDF_PLUGIN"
+    if (echo "$glidein_site" | grep -E "UW-IT|Maine-ACG") >/dev/null 2>&1; then
+        OSDF_FAIL_REASON="Stash/OSDF plugin explicitly disabled at site $glidein_site"
+    else
+        if osdf_plugin_is_ok "$REAL_OSDF_PLUGIN"; then
+            # osdf_plugin_is_ok sets $OSDF_FAIL_REASON and $OSDF_PLUGIN_VERSION
+            add_config_line FILETRANSFER_PLUGINS "\$(FILETRANSFER_PLUGINS),$OSDF_PLUGIN"
+            add_condor_vars_line FILETRANSFER_PLUGINS "C" "-" "+" "N" "N" "-"
+            set_condor_knob STASH_PLUGIN "$OSDF_PLUGIN"
+            set_condor_knob OSDF_PLUGIN "$OSDF_PLUGIN"
+            advertise "STASH_PLUGIN_VERSION" "$OSDF_PLUGIN_VERSION" "S"
+            advertise "OSDF_PLUGIN_VERSION" "$OSDF_PLUGIN_VERSION" "S"  # forward compat
         fi
     fi
+fi
 
-    # Test the stash/osdf plugin we found.
-    if [[ $OSDF_PLUGIN ]]; then
-        # add_to_debug "Stash/OSDF plugin found at" "$REAL_OSDF_PLUGIN"
-        if (echo $glidein_site | grep -E "UW-IT|Maine-ACG") >/dev/null 2>&1; then
-            OSDF_FAIL_REASON="Stash/OSDF plugin explicitly disabled at site $glidein_site"
-        else
-            if osdf_plugin_is_ok "$REAL_OSDF_PLUGIN"; then
-                # osdf_plugin_is_ok sets $OSDF_FAIL_REASON and $OSDF_PLUGIN_VERSION
-                add_config_line FILETRANSFER_PLUGINS "\$(FILETRANSFER_PLUGINS),$OSDF_PLUGIN"
-                add_condor_vars_line FILETRANSFER_PLUGINS "C" "-" "+" "N" "N" "-"
-                advertise "STASH_PLUGIN_VERSION" "$OSDF_PLUGIN_VERSION" "S"
-                advertise "OSDF_PLUGIN_VERSION" "$OSDF_PLUGIN_VERSION" "S"  # forward compat
-            fi
-        fi
-    fi
+if [[ $OSDF_FAIL_REASON ]]; then
+    advertise "OSDF_FAIL_REASON" "$OSDF_FAIL_REASON" "S"
+    # Turn off the condor config's STASH_PLUGIN and OSDF_PLUGIN in case they're set
+    set_condor_knob STASH_PLUGIN "/bin/false"
+    set_condor_knob OSDF_PLUGIN "/bin/false"
+fi
 
-    if [[ $OSDF_FAIL_REASON ]]; then
-        advertise "OSDF_FAIL_REASON" "$OSDF_FAIL_REASON" "S"
-    fi
-    [[ $DEBUG ]] && advertise "DEBUG" "$DEBUG" "S"
-fi  # ! $IS_CONTAINER_PILOT
+
 
 
 ##################################################################
@@ -504,6 +508,10 @@ if [[ ! $IS_CONTAINER_PILOT || $CONTAINER_PILOT_USE_JOB_HOOK ]]; then
     add_config_line "STARTER_DEBUG" "D_FULLDEBUG:2"
     add_condor_vars_line "STARTER_DEBUG" "C" "-" "STARTER_DEBUG" "N" "N" "-"
 fi  # ! $IS_CONTAINER_PILOT || $CONTAINER_PILOT_USE_JOB_HOOK
+
+
+# Miscellaneous debugging if any
+[[ $DEBUG ]] && advertise "DEBUG" "$DEBUG" "S"
 
 ###########################################################
 

--- a/ospool-pilot/main-canary/pilot/advertise-base
+++ b/ospool-pilot/main-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=736
+OSG_GLIDEIN_VERSION=741
 #######################################################################
 
 

--- a/ospool-pilot/main/pilot/additional-htcondor-config
+++ b/ospool-pilot/main/pilot/additional-htcondor-config
@@ -74,6 +74,13 @@ set_condor_knob () {
 
 condor_vars_file=`grep -i "^CONDOR_VARS_FILE " $glidein_config | awk '{print $2}'`
 
+# DEBUG will be advertised in the slot ad is nonempty; use add_to_debug() to add to it
+DEBUG=""
+add_to_debug () {
+    [[ $DEBUG ]] && DEBUG="${DEBUG}; "
+    DEBUG="${DEBUG}$(printf "%q " "$@")"
+}
+
 ###########################################################
 # CVMFS_BASE defaults to /cvmfs but can be overridden in case of for example cvmfsexec
 if [[ ! $CVMFS_BASE ]]; then
@@ -251,13 +258,18 @@ osdf_plugin_is_ok () {
 #       main/condor/condor-10.3.1-1-x86_64_CentOS7-stripped/usr
 # but by the time Condor starts up, it will have been moved to
 #       main/condor
-CONDOR_DIR=$(gconfig_get CONDOR_DIR)
 if [[ $IS_CONTAINER_PILOT ]]; then
+    CONDOR_DIR=/usr
     REAL_CONDOR_DIR=/usr
+    CONDOR_LIBEXEC=/usr/libexec/condor
+    REAL_CONDOR_LIBEXEC=/usr/libexec/condor
 else
+    CONDOR_DIR=$(gconfig_get CONDOR_DIR)
     # shellcheck disable=SC2086
     REAL_CONDOR_DIR=$(echo $CONDOR_DIR/condor-*/usr)
     # ^^ the "echo" is needed to expand the glob
+    CONDOR_LIBEXEC=$CONDOR_DIR/libexec
+    REAL_CONDOR_LIBEXEC=$REAL_CONDOR_DIR/libexec/condor
 fi
 
 # Get and parse condor version so we can add version-specific knobs.
@@ -290,93 +302,85 @@ fi
 #
 # If set to "condor", it will use what's in the Condor tarball.  (This can be
 # used to override a non-Condor default.)
-DEFAULT_DOWNLOAD_PELICAN_VERSION=7.6.1
+DEFAULT_DOWNLOAD_PELICAN_VERSION=7.6.2
 
 if [[ ! $DOWNLOAD_PELICAN_VERSION ]]; then
-    DOWNLOAD_PELICAN_VERSION=$DEFAULT_DOWNLOAD_PELICAN_VERSION
+    DOWNLOAD_PELICAN_VERSION=$(gconfig_get DOWNLOAD_PELICAN_VERSION)
+    if [[ ! $DOWNLOAD_PELICAN_VERSION ]]; then
+        DOWNLOAD_PELICAN_VERSION=$DEFAULT_DOWNLOAD_PELICAN_VERSION
+    fi
 fi
 
 
 ###########################################################
 # Test and add the stash/osdf plugin
 # It comes with condor, or we might be asked to download it.
-if [[ ! $IS_CONTAINER_PILOT ]]; then
-    # The container pilot has its own code for this (for now)
 
-    DEBUG=""
-    add_to_debug () {
-        [[ $DEBUG ]] && DEBUG="${DEBUG}; "
-        DEBUG="${DEBUG}$(printf "%q " "$@")"
-    }
+# Find the Stash/OSDF plugin; set OSDF_PLUGIN to its current location, and
+# set REAL_OSDF_PLUGIN to where it will be after glideinWMS has rearranged
+# the Condor install in the pilot.
+# The plugin will be tested later.
+if [[ $DOWNLOAD_PELICAN_VERSION && $DOWNLOAD_PELICAN_VERSION != condor ]]; then
+    # If this variable is set, and not set to "condor", download that
+    # version of Pelican and ignore the version from the HTCondor tarball.
 
-    CONDOR_LIBEXEC=$CONDOR_DIR/libexec
-    REAL_CONDOR_LIBEXEC=$REAL_CONDOR_DIR/libexec/condor
-
-    # add_to_debug "CONDOR_DIR=$CONDOR_DIR"
-    # add_to_debug "CONDOR_LIBEXEC=$CONDOR_LIBEXEC"
-    # add_to_debug "REAL_CONDOR_LIBEXEC=$REAL_CONDOR_LIBEXEC"
-
-    # Find the Stash/OSDF plugin; set OSDF_PLUGIN to its current location, and
-    # set REAL_OSDF_PLUGIN to where it will be after glideinWMS has rearranged
-    # the Condor install in the pilot.
-    # The plugin will be tested later.
-    if [[ $DOWNLOAD_PELICAN_VERSION && $DOWNLOAD_PELICAN_VERSION != condor ]]; then
-        # If this variable is set, and not set to "condor", download that
-        # version of Pelican and ignore the version from the HTCondor tarball.
-
-        arch=x86_64  # XXX add support for others (arm64, ppc64le)
-        url=https://github.com/PelicanPlatform/pelican/releases/download/v${DOWNLOAD_PELICAN_VERSION}/pelican_Linux_${arch}.tar.gz
-        _out=$( { 
-            curl -LSso pelican.tar.gz "$url" && 
-            tar -xzf pelican.tar.gz pelican &&
-            mv -f pelican stash_plugin &&
-            chmod +x stash_plugin
-        } 2>&1); ret=$?
-        if [[ $ret != 0 || ! -f stash_plugin || ! -x stash_plugin ]]; then
-            OSDF_FAIL_REASON="Couldn't download and install requested Pelican version ($DOWNLOAD_PELICAN_VERSION)"
-            add_to_debug "Pelican install output: $_out"
-        else
-            OSDF_PLUGIN=$(pwd -P)/stash_plugin
-            REAL_OSDF_PLUGIN=$(pwd -P)/stash_plugin
-            advertise "DOWNLOAD_PELICAN_VERSION" "$DOWNLOAD_PELICAN_VERSION" "S"
-        fi
+    url=https://github.com/PelicanPlatform/pelican/releases/download/v${DOWNLOAD_PELICAN_VERSION}/pelican_Linux_$(arch).tar.gz
+    _out=$( {
+        curl -LSso pelican.tar.gz "$url" &&
+        tar -xzf pelican.tar.gz pelican &&
+        mv -f pelican stash_plugin &&
+        chmod +x stash_plugin
+    } 2>&1); ret=$?
+    if [[ $ret != 0 || ! -f stash_plugin || ! -x stash_plugin ]]; then
+        OSDF_FAIL_REASON="Couldn't download and install requested Pelican version ($DOWNLOAD_PELICAN_VERSION)"
+        add_to_debug "Pelican install output: $_out"
     else
-        # Not asked to download a specific Pelican version, or specifically
-        # asked to use what's in the HTCondor tarball.
-        # Find the stash/osdf plugin in the HTCondor tarball.
-        if [[ -x $REAL_CONDOR_LIBEXEC/osdf_plugin ]]; then
-            # forward compat
-            OSDF_PLUGIN=$CONDOR_LIBEXEC/osdf_plugin
-            REAL_OSDF_PLUGIN=$REAL_CONDOR_LIBEXEC/osdf_plugin
-        elif [[ -x $REAL_CONDOR_LIBEXEC/stash_plugin ]]; then
-            OSDF_PLUGIN=$CONDOR_LIBEXEC/stash_plugin
-            REAL_OSDF_PLUGIN=$REAL_CONDOR_LIBEXEC/stash_plugin
-        else
-            OSDF_FAIL_REASON="Stash/OSDF plugin not found in pilot's condor install"
+        OSDF_PLUGIN=$(pwd -P)/stash_plugin
+        REAL_OSDF_PLUGIN=$(pwd -P)/stash_plugin
+        advertise "DOWNLOAD_PELICAN_VERSION" "$DOWNLOAD_PELICAN_VERSION" "S"
+    fi
+else
+    # Not asked to download a specific Pelican version, or specifically
+    # asked to use what's in the HTCondor tarball.
+    # Find the stash/osdf plugin in the HTCondor installation.
+    if [[ -x $REAL_CONDOR_LIBEXEC/osdf_plugin ]]; then
+        # forward compat
+        OSDF_PLUGIN=$CONDOR_LIBEXEC/osdf_plugin
+        REAL_OSDF_PLUGIN=$REAL_CONDOR_LIBEXEC/osdf_plugin
+    elif [[ -x $REAL_CONDOR_LIBEXEC/stash_plugin ]]; then
+        OSDF_PLUGIN=$CONDOR_LIBEXEC/stash_plugin
+        REAL_OSDF_PLUGIN=$REAL_CONDOR_LIBEXEC/stash_plugin
+    else
+        OSDF_FAIL_REASON="Stash/OSDF plugin not found in pilot's condor install"
+    fi
+fi
+
+# Test the stash/osdf plugin we found.
+if [[ $OSDF_PLUGIN ]]; then
+    # add_to_debug "Stash/OSDF plugin found at" "$REAL_OSDF_PLUGIN"
+    if (echo "$glidein_site" | grep -E "UW-IT|Maine-ACG") >/dev/null 2>&1; then
+        OSDF_FAIL_REASON="Stash/OSDF plugin explicitly disabled at site $glidein_site"
+    else
+        if osdf_plugin_is_ok "$REAL_OSDF_PLUGIN"; then
+            # osdf_plugin_is_ok sets $OSDF_FAIL_REASON and $OSDF_PLUGIN_VERSION
+            add_config_line FILETRANSFER_PLUGINS "\$(FILETRANSFER_PLUGINS),$OSDF_PLUGIN"
+            add_condor_vars_line FILETRANSFER_PLUGINS "C" "-" "+" "N" "N" "-"
+            set_condor_knob STASH_PLUGIN "$OSDF_PLUGIN"
+            set_condor_knob OSDF_PLUGIN "$OSDF_PLUGIN"
+            advertise "STASH_PLUGIN_VERSION" "$OSDF_PLUGIN_VERSION" "S"
+            advertise "OSDF_PLUGIN_VERSION" "$OSDF_PLUGIN_VERSION" "S"  # forward compat
         fi
     fi
+fi
 
-    # Test the stash/osdf plugin we found.
-    if [[ $OSDF_PLUGIN ]]; then
-        # add_to_debug "Stash/OSDF plugin found at" "$REAL_OSDF_PLUGIN"
-        if (echo $glidein_site | grep -E "UW-IT|Maine-ACG") >/dev/null 2>&1; then
-            OSDF_FAIL_REASON="Stash/OSDF plugin explicitly disabled at site $glidein_site"
-        else
-            if osdf_plugin_is_ok "$REAL_OSDF_PLUGIN"; then
-                # osdf_plugin_is_ok sets $OSDF_FAIL_REASON and $OSDF_PLUGIN_VERSION
-                add_config_line FILETRANSFER_PLUGINS "\$(FILETRANSFER_PLUGINS),$OSDF_PLUGIN"
-                add_condor_vars_line FILETRANSFER_PLUGINS "C" "-" "+" "N" "N" "-"
-                advertise "STASH_PLUGIN_VERSION" "$OSDF_PLUGIN_VERSION" "S"
-                advertise "OSDF_PLUGIN_VERSION" "$OSDF_PLUGIN_VERSION" "S"  # forward compat
-            fi
-        fi
-    fi
+if [[ $OSDF_FAIL_REASON ]]; then
+    advertise "OSDF_FAIL_REASON" "$OSDF_FAIL_REASON" "S"
+    # Turn off the condor config's STASH_PLUGIN and OSDF_PLUGIN in case they're set
+    set_condor_knob STASH_PLUGIN "/bin/false"
+    set_condor_knob OSDF_PLUGIN "/bin/false"
+fi
 
-    if [[ $OSDF_FAIL_REASON ]]; then
-        advertise "OSDF_FAIL_REASON" "$OSDF_FAIL_REASON" "S"
-    fi
-    [[ $DEBUG ]] && advertise "DEBUG" "$DEBUG" "S"
-fi  # ! $IS_CONTAINER_PILOT
+
 
 
 ##################################################################
@@ -504,6 +508,10 @@ if [[ ! $IS_CONTAINER_PILOT || $CONTAINER_PILOT_USE_JOB_HOOK ]]; then
     add_config_line "STARTER_DEBUG" "D_FULLDEBUG:2"
     add_condor_vars_line "STARTER_DEBUG" "C" "-" "STARTER_DEBUG" "N" "N" "-"
 fi  # ! $IS_CONTAINER_PILOT || $CONTAINER_PILOT_USE_JOB_HOOK
+
+
+# Miscellaneous debugging if any
+[[ $DEBUG ]] && advertise "DEBUG" "$DEBUG" "S"
 
 ###########################################################
 

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=736
+OSG_GLIDEIN_VERSION=741
 #######################################################################
 
 

--- a/ospool-pilot/main/pilot/default-image
+++ b/ospool-pilot/main/pilot/default-image
@@ -167,42 +167,6 @@ if [ "$glidein_config" != "NONE" ]; then
     add_config_line_source=$PWD/add_config_line.source
 
     source $add_config_line_source
-
-    # XXX Patch over add_config_line() with a safer version
-    # This will be fixed in gWMS 3.9.6
-    add_config_line() {
-        # Ignore the call if the exact config line is already in there
-        if ! grep -q "^${*}$" "${glidein_config}"; then
-            # Use temporary files to make sure multiple add_config_line() calls don't clobber
-            # the glidein_config.
-            local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
-            local tmp_config1="${glidein_config}.$r.1"
-            local tmp_config2="${glidein_config}.$r.2"
-
-            # Copy the glidein config so it doesn't get modified while we grep out the old value
-            if ! cp -p "${glidein_config}" "${tmp_config1}"; then
-                warn "Error writing ${tmp_config1}"
-                rm -f "${tmp_config1}"
-                exit 1
-            fi
-            grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
-            rm -f "${tmp_config1}"
-            if [ ! -f "${tmp_config2}" ]; then
-                warn "Error creating ${tmp_config2}"
-                exit 1
-            fi
-            # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
-            echo "$@" >> "${tmp_config2}"
-
-            # Replace glidein config atomically
-            if ! mv -f "${tmp_config2}" "${glidein_config}"; then
-                warn "Error updating ${glidein_config} from ${tmp_config2}"
-                rm -f "${tmp_config2}"
-                exit 1
-            fi
-        fi
-    }
-    # XXX End add_config_line() patch
 fi
 
 # source our helpers

--- a/ospool-pilot/main/pilot/singularity-extras
+++ b/ospool-pilot/main/pilot/singularity-extras
@@ -45,42 +45,6 @@ if [ "$glidein_config" != "NONE" ]; then
 
     info "Sourcing $add_config_line_source"
     source $add_config_line_source
-
-    # XXX Patch over add_config_line() with a safer version
-    # This will be fixed in gWMS 3.9.6
-    add_config_line() {
-        # Ignore the call if the exact config line is already in there
-        if ! grep -q "^${*}$" "${glidein_config}"; then
-            # Use temporary files to make sure multiple add_config_line() calls don't clobber
-            # the glidein_config.
-            local r="$(head -c16 /dev/urandom | base64 -w0 - | tr / _)"
-            local tmp_config1="${glidein_config}.$r.1"
-            local tmp_config2="${glidein_config}.$r.2"
-
-            # Copy the glidein config so it doesn't get modified while we grep out the old value
-            if ! cp -p "${glidein_config}" "${tmp_config1}"; then
-                warn "Error writing ${tmp_config1}"
-                rm -f "${tmp_config1}"
-                exit 1
-            fi
-            grep -v "^$1 " "${tmp_config1}" > "${tmp_config2}"
-            rm -f "${tmp_config1}"
-            if [ ! -f "${tmp_config2}" ]; then
-                warn "Error creating ${tmp_config2}"
-                exit 1
-            fi
-            # NOTE that parameters are flattened if not quoted, if there are blanks they are separated by single space
-            echo "$@" >> "${tmp_config2}"
-
-            # Replace glidein config atomically
-            if ! mv -f "${tmp_config2}" "${glidein_config}"; then
-                warn "Error updating ${glidein_config} from ${tmp_config2}"
-                rm -f "${tmp_config2}"
-                exit 1
-            fi
-        fi
-    }
-    # XXX End add_config_line() patch
 fi
 
 # source our helpers


### PR DESCRIPTION
This allows container pilots to also download a specific version of Pelican, and use the test logic in additional-htcondor-config instead of having to implement their own.  (After this is merged, the OSDF plugin tests can be removed from osgvo-docker-pilot.)

Other changes:

- DEFAULT_PELICAN_VERSION bumped to 7.6.2; it can now be overridden by a glidein param, not just an env var
- Stopped patching over glideinwms's add_config_line() -- it was fixed a long time ago