### PR TITLE
itb, itb-canary 746: don't use floating point math to calculate allocated_disk

### DIFF
--- a/ospool-pilot/itb-canary/pilot/additional-htcondor-config
+++ b/ospool-pilot/itb-canary/pilot/additional-htcondor-config
@@ -122,12 +122,9 @@ if [[ ! $IS_CONTAINER_PILOT ]]; then
     allocated_cpus=$(grep -i "^GLIDEIN_CPUS " "$glidein_config" | cut -d ' ' -f 2-)
     total_cpus=$(cat /proc/cpuinfo | egrep "^processor" | wc -l)
     if [[ $allocated_cpus -gt 0 && $total_cpus -gt 0 ]]; then
-        # first try floating point
-        allocated_disk=$(echo "scale=2; 100 * $allocated_cpus / $total_cpus" | bc)
-        if [ "x$allocated_disk" = "x" ]; then
-            # no bc, use integer math
-            allocated_disk=$((100 * $allocated_cpus / $total_cpus))
-        fi
+        # the bash [ and [[ operators don't accept floating point so we must
+        # use integer math
+        allocated_disk=$((100 * $allocated_cpus / $total_cpus))
         if [ "x$allocated_disk" = "x" ]; then
             allocated_disk=1
         fi

--- a/ospool-pilot/itb-canary/pilot/advertise-base
+++ b/ospool-pilot/itb-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=745
+OSG_GLIDEIN_VERSION=746
 #######################################################################
 
 

--- a/ospool-pilot/itb/pilot/additional-htcondor-config
+++ b/ospool-pilot/itb/pilot/additional-htcondor-config
@@ -122,12 +122,9 @@ if [[ ! $IS_CONTAINER_PILOT ]]; then
     allocated_cpus=$(grep -i "^GLIDEIN_CPUS " "$glidein_config" | cut -d ' ' -f 2-)
     total_cpus=$(cat /proc/cpuinfo | egrep "^processor" | wc -l)
     if [[ $allocated_cpus -gt 0 && $total_cpus -gt 0 ]]; then
-        # first try floating point
-        allocated_disk=$(echo "scale=2; 100 * $allocated_cpus / $total_cpus" | bc)
-        if [ "x$allocated_disk" = "x" ]; then
-            # no bc, use integer math
-            allocated_disk=$((100 * $allocated_cpus / $total_cpus))
-        fi
+        # the bash [ and [[ operators don't accept floating point so we must
+        # use integer math
+        allocated_disk=$((100 * $allocated_cpus / $total_cpus))
         if [ "x$allocated_disk" = "x" ]; then
             allocated_disk=1
         fi

--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=745
+OSG_GLIDEIN_VERSION=746
 #######################################################################
 
 


### PR DESCRIPTION
the bash [ and [[ operators don't accept floating point (we get stuff like

    bash: [[: 35.4: syntax error: invalid arithmetic operator (error token is ".4")

so stick with integer math.