### PR TITLE
main, main-canary 745: update to Pelican 7.7.3

### DIFF
--- a/ospool-pilot/main-canary/pilot/additional-htcondor-config
+++ b/ospool-pilot/main-canary/pilot/additional-htcondor-config
@@ -302,7 +302,7 @@ fi
 #
 # If set to "condor", it will use what's in the Condor tarball.  (This can be
 # used to override a non-Condor default.)
-DEFAULT_DOWNLOAD_PELICAN_VERSION=7.6.2
+DEFAULT_DOWNLOAD_PELICAN_VERSION=7.7.3
 
 if [[ ! $DOWNLOAD_PELICAN_VERSION ]]; then
     DOWNLOAD_PELICAN_VERSION=$(gconfig_get DOWNLOAD_PELICAN_VERSION)

--- a/ospool-pilot/main-canary/pilot/advertise-base
+++ b/ospool-pilot/main-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=741
+OSG_GLIDEIN_VERSION=745
 #######################################################################
 
 

--- a/ospool-pilot/main/pilot/additional-htcondor-config
+++ b/ospool-pilot/main/pilot/additional-htcondor-config
@@ -302,7 +302,7 @@ fi
 #
 # If set to "condor", it will use what's in the Condor tarball.  (This can be
 # used to override a non-Condor default.)
-DEFAULT_DOWNLOAD_PELICAN_VERSION=7.6.2
+DEFAULT_DOWNLOAD_PELICAN_VERSION=7.7.3
 
 if [[ ! $DOWNLOAD_PELICAN_VERSION ]]; then
     DOWNLOAD_PELICAN_VERSION=$(gconfig_get DOWNLOAD_PELICAN_VERSION)

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=741
+OSG_GLIDEIN_VERSION=745
 #######################################################################
 
 


### PR DESCRIPTION
https://github.com/PelicanPlatform/pelican/releases/tag/v7.7.3

This has been running on ITB since Wednesday.