### PR TITLE
itb, itb-canary 747: more robustly advertise STASHCP_VERSION

### DIFF
--- a/ospool-pilot/itb-canary/pilot/advertise-base
+++ b/ospool-pilot/itb-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=746
+OSG_GLIDEIN_VERSION=747
 #######################################################################
 
 

--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=746
+OSG_GLIDEIN_VERSION=747
 #######################################################################
 
 

--- a/ospool-pilot/itb/pilot/advertise-userenv
+++ b/ospool-pilot/itb/pilot/advertise-userenv
@@ -281,10 +281,15 @@ if (cat /stash/user/test.osgconnect.1M) >/dev/null 2>&1; then
 fi
 
 # advertise the version of stashcp found in $PATH
-if STASHCP_VERSION=$(stashcp --version)
-then
-    STASHCP_VERSION=$(echo "$STASHCP_VERSION" | head -n1 | grep -o "[0-9][0-9.]\+")
-    advertise STASHCP_VERSION "$STASHCP_VERSION" "S"
+if STASHCP_VERSION=$(stashcp --version 2>&1); then
+    STASHCP_VERSION=$(echo "$STASHCP_VERSION" | grep '^Version:' | grep -o "[0-9][0-9.]\+")
+    if [[ $STASHCP_VERSION ]]; then
+        advertise STASHCP_VERSION "$STASHCP_VERSION" "S"
+    else
+        # malformed version; assume it's broken
+        advertise STASHCP_VERSION UNDEFINED "C"
+        advertise STASHCP_VERIFIED "False" "C"
+    fi
 else
     # version check failed; we don't actually have a working stashcp
     advertise STASHCP_VERSION UNDEFINED "C"


### PR DESCRIPTION
- capture stderr (pelican 7.7.3 outputs version to stderr)
- don't assume the version is on the first line
- make sure we don't try to advertise the empty string: that fails later in set_var