### PR TITLE
main, main-canary 747: bring up-to-date with itb 747

### DIFF
--- a/ospool-pilot/main-canary/pilot/additional-htcondor-config
+++ b/ospool-pilot/main-canary/pilot/additional-htcondor-config
@@ -122,12 +122,9 @@ if [[ ! $IS_CONTAINER_PILOT ]]; then
     allocated_cpus=$(grep -i "^GLIDEIN_CPUS " "$glidein_config" | cut -d ' ' -f 2-)
     total_cpus=$(cat /proc/cpuinfo | egrep "^processor" | wc -l)
     if [[ $allocated_cpus -gt 0 && $total_cpus -gt 0 ]]; then
-        # first try floating point
-        allocated_disk=$(echo "scale=2; 100 * $allocated_cpus / $total_cpus" | bc)
-        if [ "x$allocated_disk" = "x" ]; then
-            # no bc, use integer math
-            allocated_disk=$((100 * $allocated_cpus / $total_cpus))
-        fi
+        # the bash [ and [[ operators don't accept floating point so we must
+        # use integer math
+        allocated_disk=$((100 * $allocated_cpus / $total_cpus))
         if [ "x$allocated_disk" = "x" ]; then
             allocated_disk=1
         fi

--- a/ospool-pilot/main-canary/pilot/advertise-base
+++ b/ospool-pilot/main-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=745
+OSG_GLIDEIN_VERSION=747
 #######################################################################
 
 

--- a/ospool-pilot/main-canary/pilot/advertise-userenv
+++ b/ospool-pilot/main-canary/pilot/advertise-userenv
@@ -281,10 +281,15 @@ if (cat /stash/user/test.osgconnect.1M) >/dev/null 2>&1; then
 fi
 
 # advertise the version of stashcp found in $PATH
-if STASHCP_VERSION=$(stashcp --version)
-then
-    STASHCP_VERSION=$(echo "$STASHCP_VERSION" | head -n1 | grep -o "[0-9][0-9.]\+")
-    advertise STASHCP_VERSION "$STASHCP_VERSION" "S"
+if STASHCP_VERSION=$(stashcp --version 2>&1); then
+    STASHCP_VERSION=$(echo "$STASHCP_VERSION" | grep '^Version:' | grep -o "[0-9][0-9.]\+")
+    if [[ $STASHCP_VERSION ]]; then
+        advertise STASHCP_VERSION "$STASHCP_VERSION" "S"
+    else
+        # malformed version; assume it's broken
+        advertise STASHCP_VERSION UNDEFINED "C"
+        advertise STASHCP_VERIFIED "False" "C"
+    fi
 else
     # version check failed; we don't actually have a working stashcp
     advertise STASHCP_VERSION UNDEFINED "C"

--- a/ospool-pilot/main/pilot/additional-htcondor-config
+++ b/ospool-pilot/main/pilot/additional-htcondor-config
@@ -122,12 +122,9 @@ if [[ ! $IS_CONTAINER_PILOT ]]; then
     allocated_cpus=$(grep -i "^GLIDEIN_CPUS " "$glidein_config" | cut -d ' ' -f 2-)
     total_cpus=$(cat /proc/cpuinfo | egrep "^processor" | wc -l)
     if [[ $allocated_cpus -gt 0 && $total_cpus -gt 0 ]]; then
-        # first try floating point
-        allocated_disk=$(echo "scale=2; 100 * $allocated_cpus / $total_cpus" | bc)
-        if [ "x$allocated_disk" = "x" ]; then
-            # no bc, use integer math
-            allocated_disk=$((100 * $allocated_cpus / $total_cpus))
-        fi
+        # the bash [ and [[ operators don't accept floating point so we must
+        # use integer math
+        allocated_disk=$((100 * $allocated_cpus / $total_cpus))
         if [ "x$allocated_disk" = "x" ]; then
             allocated_disk=1
         fi

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=745
+OSG_GLIDEIN_VERSION=747
 #######################################################################
 
 

--- a/ospool-pilot/main/pilot/advertise-userenv
+++ b/ospool-pilot/main/pilot/advertise-userenv
@@ -281,10 +281,15 @@ if (cat /stash/user/test.osgconnect.1M) >/dev/null 2>&1; then
 fi
 
 # advertise the version of stashcp found in $PATH
-if STASHCP_VERSION=$(stashcp --version)
-then
-    STASHCP_VERSION=$(echo "$STASHCP_VERSION" | head -n1 | grep -o "[0-9][0-9.]\+")
-    advertise STASHCP_VERSION "$STASHCP_VERSION" "S"
+if STASHCP_VERSION=$(stashcp --version 2>&1); then
+    STASHCP_VERSION=$(echo "$STASHCP_VERSION" | grep '^Version:' | grep -o "[0-9][0-9.]\+")
+    if [[ $STASHCP_VERSION ]]; then
+        advertise STASHCP_VERSION "$STASHCP_VERSION" "S"
+    else
+        # malformed version; assume it's broken
+        advertise STASHCP_VERSION UNDEFINED "C"
+        advertise STASHCP_VERIFIED "False" "C"
+    fi
 else
     # version check failed; we don't actually have a working stashcp
     advertise STASHCP_VERSION UNDEFINED "C"


### PR DESCRIPTION
Includes the following changes:
- more robustly advertise STASHCP_VERSION (#285)
- don't use floating point math to calculate allocated_disk (#283)