### PR TITLE
INF-1890 Have glidein scripts look in both base and group client dirs

### DIFF
--- a/ospool-pilot/itb-canary/job/prepare-hook
+++ b/ospool-pilot/itb-canary/job/prepare-hook
@@ -150,20 +150,33 @@ function get_glidein_config_value {
 
 # OS Pool helpers
 # source our helpers
+client_dir=$(get_glidein_config_value GLIDECLIENT_WORK_DIR)
 group_dir=$(get_glidein_config_value GLIDECLIENT_GROUP_WORK_DIR)
-if [ ! -d "$group_dir" ]; then
-    exit_hook_stop_pilot 303 "GLIDECLIENT_GROUP_WORK_DIR ($group_dir) is empty or not a directory"
+if [ ! -d "$group_dir" ] && [ ! -d "$client_dir" ]; then
+    exit_hook_stop_pilot 303 "GLIDECLIENT_WORK_DIR ($client_dir) and GLIDECLIENT_GROUP_WORK_DIR ($group_dir) are empty or not directories"
 fi
 if [ -e "$group_dir/itb-ospool-lib" ]; then
     source "$group_dir/itb-ospool-lib" || {
         error_message="Unable to source itb-ospool-lib; group_dir is $group_dir; $(ls -ld "$group_dir" 2>&1); $(ls -ld "$group_dir/itb-ospool-lib" 2>&1)"
         exit_hook_stop_pilot 304 "$error_message"
     }
-else
+elif [ -e "$group_dir/ospool-lib" ]; then
     source "$group_dir/ospool-lib" || {
         error_message="Unable to source ospool-lib; group_dir is $group_dir; $(ls -ld "$group_dir" 2>&1); $(ls -ld "$group_dir/ospool-lib" 2>&1)"
         exit_hook_stop_pilot 304 "$error_message"
     }
+elif [ -e "$client_dir/itb-ospool-lib" ]; then
+    source "$client_dir/itb-ospool-lib" || {
+        error_message="Unable to source itb-ospool-lib; client_dir is $client_dir; $(ls -ld "$client_dir" 2>&1); $(ls -ld "$client_dir/itb-ospool-lib" 2>&1)"
+        exit_hook_stop_pilot 304 "$error_message"
+    }
+elif [ -e "$client_dir/ospool-lib" ]; then
+    source "$client_dir/ospool-lib" || {
+        error_message="Unable to source ospool-lib; client_dir is $client_dir; $(ls -ld "$client_dir" 2>&1); $(ls -ld "$client_dir/ospool-lib" 2>&1)"
+        exit_hook_stop_pilot 304 "$error_message"
+    }
+else
+    exit_hook_stop_pilot 304 "Unable to find ospool-lib in client_dir or group_dir"
 fi
 
 

--- a/ospool-pilot/itb-canary/pilot/additional-htcondor-config
+++ b/ospool-pilot/itb-canary/pilot/additional-htcondor-config
@@ -476,8 +476,11 @@ add_condor_vars_line "OSG_USING_JOB_HOOK" "C" "-" "+" "Y" "Y" "-"
 # the Singularity container outside of the glidein default
 # image.
 if [[ ! $IS_CONTAINER_PILOT || $CONTAINER_PILOT_USE_JOB_HOOK ]]; then
+    glidein_client_dir=`grep -i "^GLIDECLIENT_WORK_DIR " $glidein_config | awk '{print $2}'`
     glidein_group_dir=`grep -i "^GLIDECLIENT_GROUP_WORK_DIR " $glidein_config | awk '{print $2}'`
-    for search_path in $glidein_group_dir/{prepare-hook,itb-prepare-hook,itb-prepare-hook-lib}; do
+    for search_path in \
+        $glidein_group_dir/{prepare-hook,itb-prepare-hook,itb-prepare-hook-lib} \
+        $glidein_client_dir/{prepare-hook,itb-prepare-hook,itb-prepare-hook-lib}; do
         if [[ -e $search_path ]]; then
             hook_path=$search_path
         fi

--- a/ospool-pilot/itb/job/prepare-hook
+++ b/ospool-pilot/itb/job/prepare-hook
@@ -150,20 +150,33 @@ function get_glidein_config_value {
 
 # OS Pool helpers
 # source our helpers
+client_dir=$(get_glidein_config_value GLIDECLIENT_WORK_DIR)
 group_dir=$(get_glidein_config_value GLIDECLIENT_GROUP_WORK_DIR)
-if [ ! -d "$group_dir" ]; then
-    exit_hook_stop_pilot 303 "GLIDECLIENT_GROUP_WORK_DIR ($group_dir) is empty or not a directory"
+if [ ! -d "$group_dir" ] && [ ! -d "$client_dir" ]; then
+    exit_hook_stop_pilot 303 "GLIDECLIENT_WORK_DIR ($client_dir) and GLIDECLIENT_GROUP_WORK_DIR ($group_dir) are empty or not directories"
 fi
 if [ -e "$group_dir/itb-ospool-lib" ]; then
     source "$group_dir/itb-ospool-lib" || {
         error_message="Unable to source itb-ospool-lib; group_dir is $group_dir; $(ls -ld "$group_dir" 2>&1); $(ls -ld "$group_dir/itb-ospool-lib" 2>&1)"
         exit_hook_stop_pilot 304 "$error_message"
     }
-else
+elif [ -e "$group_dir/ospool-lib" ]; then
     source "$group_dir/ospool-lib" || {
         error_message="Unable to source ospool-lib; group_dir is $group_dir; $(ls -ld "$group_dir" 2>&1); $(ls -ld "$group_dir/ospool-lib" 2>&1)"
         exit_hook_stop_pilot 304 "$error_message"
     }
+elif [ -e "$client_dir/itb-ospool-lib" ]; then
+    source "$client_dir/itb-ospool-lib" || {
+        error_message="Unable to source itb-ospool-lib; client_dir is $client_dir; $(ls -ld "$client_dir" 2>&1); $(ls -ld "$client_dir/itb-ospool-lib" 2>&1)"
+        exit_hook_stop_pilot 304 "$error_message"
+    }
+elif [ -e "$client_dir/ospool-lib" ]; then
+    source "$client_dir/ospool-lib" || {
+        error_message="Unable to source ospool-lib; client_dir is $client_dir; $(ls -ld "$client_dir" 2>&1); $(ls -ld "$client_dir/ospool-lib" 2>&1)"
+        exit_hook_stop_pilot 304 "$error_message"
+    }
+else
+    exit_hook_stop_pilot 304 "Unable to find ospool-lib in client_dir or group_dir"
 fi
 
 

--- a/ospool-pilot/itb/pilot/additional-htcondor-config
+++ b/ospool-pilot/itb/pilot/additional-htcondor-config
@@ -476,8 +476,11 @@ add_condor_vars_line "OSG_USING_JOB_HOOK" "C" "-" "+" "Y" "Y" "-"
 # the Singularity container outside of the glidein default
 # image.
 if [[ ! $IS_CONTAINER_PILOT || $CONTAINER_PILOT_USE_JOB_HOOK ]]; then
+    glidein_client_dir=`grep -i "^GLIDECLIENT_WORK_DIR " $glidein_config | awk '{print $2}'`
     glidein_group_dir=`grep -i "^GLIDECLIENT_GROUP_WORK_DIR " $glidein_config | awk '{print $2}'`
-    for search_path in $glidein_group_dir/{prepare-hook,itb-prepare-hook,itb-prepare-hook-lib}; do
+    for search_path in \
+        $glidein_group_dir/{prepare-hook,itb-prepare-hook,itb-prepare-hook-lib} \
+        $glidein_client_dir/{prepare-hook,itb-prepare-hook,itb-prepare-hook-lib}; do
         if [[ -e $search_path ]]; then
             hook_path=$search_path
         fi

--- a/ospool-pilot/itb/pilot/default-image
+++ b/ospool-pilot/itb/pilot/default-image
@@ -170,11 +170,18 @@ if [ "$glidein_config" != "NONE" ]; then
 fi
 
 # source our helpers
+client_dir=$(get_glidein_config_value GLIDECLIENT_WORK_DIR)
 group_dir=$(get_glidein_config_value GLIDECLIENT_GROUP_WORK_DIR)
 if [ -e "$group_dir/itb-ospool-lib" ]; then
     source "$group_dir/itb-ospool-lib"
-else
+elif [ -e "$group_dir/ospool-lib" ]; then
     source "$group_dir/ospool-lib"
+elif [ -e "$client_dir/itb-ospool-lib" ]; then
+    source "$client_dir/itb-ospool-lib"
+elif [ -e "$client_dir/ospool-lib" ]; then
+    source "$client_dir/ospool-lib"
+else
+    echo "ERROR   Failed to find ospool-lib in GLIDECLIENT_WORK_DIR or GLIDECLIENT_GROUP_WORK_DIR" 1>&2
 fi
 
 determine_default_container_image

--- a/ospool-pilot/itb/pilot/singularity-extras
+++ b/ospool-pilot/itb/pilot/singularity-extras
@@ -48,11 +48,18 @@ if [ "$glidein_config" != "NONE" ]; then
 fi
 
 # source our helpers
+client_dir=$(get_glidein_config_value GLIDECLIENT_WORK_DIR)
 group_dir=$(get_glidein_config_value GLIDECLIENT_GROUP_WORK_DIR)
 if [ -e "$group_dir/itb-ospool-lib" ]; then
     source "$group_dir/itb-ospool-lib"
-else
+elif [ -e "$group_dir/ospool-lib" ]; then
     source "$group_dir/ospool-lib"
+elif [ -e "$client_dir/itb-ospool-lib" ]; then
+    source "$client_dir/itb-ospool-lib"
+elif [ -e "$client_dir/ospool-lib" ]; then
+    source "$client_dir/ospool-lib"
+else
+    echo "ERROR   Failed to find ospool-lib in GLIDECLIENT_WORK_DIR or GLIDECLIENT_GROUP_WORK_DIR" 1>&2
 fi
 
 # make sure singularity can do overlay/underlay


### PR DESCRIPTION
The OSPool frontend defines its lists of files separately inside each frontend group, whereas other frontends may (and do) list files in the top-level frontend config. A small difference that unfortunately has consequences in where files are placed, dependencies (such as `ospool-lib` and `prepare-job-hook`) may thus be in either or both of `GLIDECLIENT_GROUP_WORK_DIR` and `GLIDECLIENT_WORK_DIR`.

There's probably a better way to handle this, these are just the quickest changes I could come up with.