### PR TITLE
INF-1890 Copy helper/hook scripts from frontend client dir if needed

### DIFF
--- a/ospool-pilot/itb-canary/job/prepare-hook
+++ b/ospool-pilot/itb-canary/job/prepare-hook
@@ -154,6 +154,8 @@ group_dir=$(get_glidein_config_value GLIDECLIENT_GROUP_WORK_DIR)
 if [ ! -d "$group_dir" ]; then
     exit_hook_stop_pilot 303 "GLIDECLIENT_GROUP_WORK_DIR ($group_dir) is empty or not a directory"
 fi
+client_dir=$(get_glidein_config_value GLIDECLIENT_WORK_DIR)
+cp -ns $client_dir/*ospool-lib $group_dir/ 2>/dev/null && echo "Linking helper(s) from $(ls $client_dir/*ospool-lib | tr '\n' ' ')" 1>&2
 if [ -e "$group_dir/itb-ospool-lib" ]; then
     source "$group_dir/itb-ospool-lib" || {
         error_message="Unable to source itb-ospool-lib; group_dir is $group_dir; $(ls -ld "$group_dir" 2>&1); $(ls -ld "$group_dir/itb-ospool-lib" 2>&1)"

--- a/ospool-pilot/itb-canary/pilot/additional-htcondor-config
+++ b/ospool-pilot/itb-canary/pilot/additional-htcondor-config
@@ -477,6 +477,9 @@ add_condor_vars_line "OSG_USING_JOB_HOOK" "C" "-" "+" "Y" "Y" "-"
 # image.
 if [[ ! $IS_CONTAINER_PILOT || $CONTAINER_PILOT_USE_JOB_HOOK ]]; then
     glidein_group_dir=`grep -i "^GLIDECLIENT_GROUP_WORK_DIR " $glidein_config | awk '{print $2}'`
+    glidein_client_dir=`grep -i "^GLIDECLIENT_WORK_DIR " $glidein_config | awk '{print $2}'`
+    cp -ns $glidein_client_dir/*prepare-hook* $glidein_group_dir/ 2>/dev/null && \
+        info "Linking hook(s) from $(ls $glidein_client_dir/*prepare-hook* | tr '\n' ' ')"
     for search_path in $glidein_group_dir/{prepare-hook,itb-prepare-hook,itb-prepare-hook-lib}; do
         if [[ -e $search_path ]]; then
             hook_path=$search_path

--- a/ospool-pilot/itb/job/prepare-hook
+++ b/ospool-pilot/itb/job/prepare-hook
@@ -154,6 +154,8 @@ group_dir=$(get_glidein_config_value GLIDECLIENT_GROUP_WORK_DIR)
 if [ ! -d "$group_dir" ]; then
     exit_hook_stop_pilot 303 "GLIDECLIENT_GROUP_WORK_DIR ($group_dir) is empty or not a directory"
 fi
+client_dir=$(get_glidein_config_value GLIDECLIENT_WORK_DIR)
+cp -ns $client_dir/*ospool-lib $group_dir/ 2>/dev/null && echo "Linking helper(s) from $(ls $client_dir/*ospool-lib | tr '\n' ' ')" 1>&2
 if [ -e "$group_dir/itb-ospool-lib" ]; then
     source "$group_dir/itb-ospool-lib" || {
         error_message="Unable to source itb-ospool-lib; group_dir is $group_dir; $(ls -ld "$group_dir" 2>&1); $(ls -ld "$group_dir/itb-ospool-lib" 2>&1)"

--- a/ospool-pilot/itb/pilot/additional-htcondor-config
+++ b/ospool-pilot/itb/pilot/additional-htcondor-config
@@ -477,6 +477,9 @@ add_condor_vars_line "OSG_USING_JOB_HOOK" "C" "-" "+" "Y" "Y" "-"
 # image.
 if [[ ! $IS_CONTAINER_PILOT || $CONTAINER_PILOT_USE_JOB_HOOK ]]; then
     glidein_group_dir=`grep -i "^GLIDECLIENT_GROUP_WORK_DIR " $glidein_config | awk '{print $2}'`
+    glidein_client_dir=`grep -i "^GLIDECLIENT_WORK_DIR " $glidein_config | awk '{print $2}'`
+    cp -ns $glidein_client_dir/*prepare-hook* $glidein_group_dir/ 2>/dev/null && \
+        info "Linking hook(s) from $(ls $glidein_client_dir/*prepare-hook* | tr '\n' ' ')"
     for search_path in $glidein_group_dir/{prepare-hook,itb-prepare-hook,itb-prepare-hook-lib}; do
         if [[ -e $search_path ]]; then
             hook_path=$search_path

--- a/ospool-pilot/itb/pilot/default-image
+++ b/ospool-pilot/itb/pilot/default-image
@@ -171,6 +171,8 @@ fi
 
 # source our helpers
 group_dir=$(get_glidein_config_value GLIDECLIENT_GROUP_WORK_DIR)
+client_dir=$(get_glidein_config_value GLIDECLIENT_WORK_DIR)
+cp -ns $client_dir/*ospool-lib $group_dir/ 2>/dev/null && echo "Linking helper(s) from $(ls $client_dir/*ospool-lib | tr '\n' ' ')" 1>&2
 if [ -e "$group_dir/itb-ospool-lib" ]; then
     source "$group_dir/itb-ospool-lib"
 else

--- a/ospool-pilot/itb/pilot/singularity-extras
+++ b/ospool-pilot/itb/pilot/singularity-extras
@@ -49,6 +49,8 @@ fi
 
 # source our helpers
 group_dir=$(get_glidein_config_value GLIDECLIENT_GROUP_WORK_DIR)
+client_dir=$(get_glidein_config_value GLIDECLIENT_WORK_DIR)
+cp -ns $client_dir/*ospool-lib $group_dir/ 2>/dev/null && info "Linking helper(s) from $(ls $client_dir/*ospool-lib | tr '\n' ' ')"
 if [ -e "$group_dir/itb-ospool-lib" ]; then
     source "$group_dir/itb-ospool-lib"
 else


### PR DESCRIPTION
The OSPool frontend defines its lists of files separately inside each frontend group, whereas other frontends may and do list files in the top-level frontend config. This means that dependencies may be in either or both `GLIDECLIENT_GROUP_WORK_DIR` and `GLIDECLIENT_WORK_DIR`. This commit copies/links any helper/hook scripts found in `GLIDECLIENT_WORK_DIR` into `GLIDECLIENT_GROUP_WORK_DIR` as necessary.

Obsoletes #297 