### PR TITLE
main, main-canary 756: bring up-to-date with itb 756

### DIFF
--- a/ospool-pilot/main-canary/job/prepare-hook
+++ b/ospool-pilot/main-canary/job/prepare-hook
@@ -154,6 +154,8 @@ group_dir=$(get_glidein_config_value GLIDECLIENT_GROUP_WORK_DIR)
 if [ ! -d "$group_dir" ]; then
     exit_hook_stop_pilot 303 "GLIDECLIENT_GROUP_WORK_DIR ($group_dir) is empty or not a directory"
 fi
+client_dir=$(get_glidein_config_value GLIDECLIENT_WORK_DIR)
+cp -ns $client_dir/*ospool-lib $group_dir/ 2>/dev/null && echo "Linking helper(s) from $(ls $client_dir/*ospool-lib | tr '\n' ' ')" 1>&2
 if [ -e "$group_dir/itb-ospool-lib" ]; then
     source "$group_dir/itb-ospool-lib" || {
         error_message="Unable to source itb-ospool-lib; group_dir is $group_dir; $(ls -ld "$group_dir" 2>&1); $(ls -ld "$group_dir/itb-ospool-lib" 2>&1)"

--- a/ospool-pilot/main-canary/pilot/additional-htcondor-config
+++ b/ospool-pilot/main-canary/pilot/additional-htcondor-config
@@ -224,7 +224,7 @@ osdf_plugin_is_ok () {
             info "Succeeded!"
         fi
 
-        OSDF_PLUGIN_VERSION=$("$OSDF_PLUGIN" -classad | awk '/^PluginVersion / { print $3 }' | tr -d '"' 2>>stashcp-test.log)
+        OSDF_PLUGIN_VERSION=$("$OSDF_PLUGIN" -classad | awk '/^(Pelican)?PluginVersion / { print $3; exit }' | tr -d '"' 2>>stashcp-test.log)
         if [[ $OSDF_PLUGIN_VERSION ]]; then
             OSDF_FAIL_REASON=""
         else
@@ -299,7 +299,7 @@ fi
 #
 # If set to "condor", it will use what's in the Condor tarball.  (This can be
 # used to override a non-Condor default.)
-DEFAULT_DOWNLOAD_PELICAN_VERSION=7.7.4
+DEFAULT_DOWNLOAD_PELICAN_VERSION=7.8.1
 
 if [[ ! $DOWNLOAD_PELICAN_VERSION ]]; then
     DOWNLOAD_PELICAN_VERSION=$(gconfig_get DOWNLOAD_PELICAN_VERSION)
@@ -477,6 +477,9 @@ add_condor_vars_line "OSG_USING_JOB_HOOK" "C" "-" "+" "Y" "Y" "-"
 # image.
 if [[ ! $IS_CONTAINER_PILOT || $CONTAINER_PILOT_USE_JOB_HOOK ]]; then
     glidein_group_dir=`grep -i "^GLIDECLIENT_GROUP_WORK_DIR " $glidein_config | awk '{print $2}'`
+    glidein_client_dir=`grep -i "^GLIDECLIENT_WORK_DIR " $glidein_config | awk '{print $2}'`
+    cp -ns $glidein_client_dir/*prepare-hook* $glidein_group_dir/ 2>/dev/null && \
+        info "Linking hook(s) from $(ls $glidein_client_dir/*prepare-hook* | tr '\n' ' ')"
     for search_path in $glidein_group_dir/{prepare-hook,itb-prepare-hook,itb-prepare-hook-lib}; do
         if [[ -e $search_path ]]; then
             hook_path=$search_path

--- a/ospool-pilot/main-canary/pilot/advertise-base
+++ b/ospool-pilot/main-canary/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=749
+OSG_GLIDEIN_VERSION=756
 #######################################################################
 
 
@@ -313,9 +313,14 @@ advertise HAS_unsquashfs "$HAS_unsquashfs" "C"
 
 # check for locally cached .sif images - this will be helpful when determining 
 # we want to disable Singularity if CVMFS is not available
+# while we're at it, advertise the size
 GWMS_SINGULARITY_CACHED_IMAGES=$( (cd images/ && ls *.sif | sort | paste -d, -s) 2>/dev/null)
 if [[ "x$GWMS_SINGULARITY_CACHED_IMAGES" != "x" ]]; then
     advertise GWMS_SINGULARITY_CACHED_IMAGES "$GWMS_SINGULARITY_CACHED_IMAGES" "S"
+fi
+GWMS_SINGULARITY_CACHED_IMAGES_KB=$( (du -kc images/*.sif | tail -n 1 | awk '{print $1}') 2>/dev/null)
+if [[ "x$GWMS_SINGULARITY_CACHED_IMAGES_KB" != "x" ]]; then
+    advertise GWMS_SINGULARITY_CACHED_IMAGES_KB "$GWMS_SINGULARITY_CACHED_IMAGES_KB" "I"
 fi
 
 

--- a/ospool-pilot/main/job/prepare-hook
+++ b/ospool-pilot/main/job/prepare-hook
@@ -154,6 +154,8 @@ group_dir=$(get_glidein_config_value GLIDECLIENT_GROUP_WORK_DIR)
 if [ ! -d "$group_dir" ]; then
     exit_hook_stop_pilot 303 "GLIDECLIENT_GROUP_WORK_DIR ($group_dir) is empty or not a directory"
 fi
+client_dir=$(get_glidein_config_value GLIDECLIENT_WORK_DIR)
+cp -ns $client_dir/*ospool-lib $group_dir/ 2>/dev/null && echo "Linking helper(s) from $(ls $client_dir/*ospool-lib | tr '\n' ' ')" 1>&2
 if [ -e "$group_dir/itb-ospool-lib" ]; then
     source "$group_dir/itb-ospool-lib" || {
         error_message="Unable to source itb-ospool-lib; group_dir is $group_dir; $(ls -ld "$group_dir" 2>&1); $(ls -ld "$group_dir/itb-ospool-lib" 2>&1)"

--- a/ospool-pilot/main/pilot/additional-htcondor-config
+++ b/ospool-pilot/main/pilot/additional-htcondor-config
@@ -224,7 +224,7 @@ osdf_plugin_is_ok () {
             info "Succeeded!"
         fi
 
-        OSDF_PLUGIN_VERSION=$("$OSDF_PLUGIN" -classad | awk '/^PluginVersion / { print $3 }' | tr -d '"' 2>>stashcp-test.log)
+        OSDF_PLUGIN_VERSION=$("$OSDF_PLUGIN" -classad | awk '/^(Pelican)?PluginVersion / { print $3; exit }' | tr -d '"' 2>>stashcp-test.log)
         if [[ $OSDF_PLUGIN_VERSION ]]; then
             OSDF_FAIL_REASON=""
         else
@@ -299,7 +299,7 @@ fi
 #
 # If set to "condor", it will use what's in the Condor tarball.  (This can be
 # used to override a non-Condor default.)
-DEFAULT_DOWNLOAD_PELICAN_VERSION=7.7.4
+DEFAULT_DOWNLOAD_PELICAN_VERSION=7.8.1
 
 if [[ ! $DOWNLOAD_PELICAN_VERSION ]]; then
     DOWNLOAD_PELICAN_VERSION=$(gconfig_get DOWNLOAD_PELICAN_VERSION)
@@ -477,6 +477,9 @@ add_condor_vars_line "OSG_USING_JOB_HOOK" "C" "-" "+" "Y" "Y" "-"
 # image.
 if [[ ! $IS_CONTAINER_PILOT || $CONTAINER_PILOT_USE_JOB_HOOK ]]; then
     glidein_group_dir=`grep -i "^GLIDECLIENT_GROUP_WORK_DIR " $glidein_config | awk '{print $2}'`
+    glidein_client_dir=`grep -i "^GLIDECLIENT_WORK_DIR " $glidein_config | awk '{print $2}'`
+    cp -ns $glidein_client_dir/*prepare-hook* $glidein_group_dir/ 2>/dev/null && \
+        info "Linking hook(s) from $(ls $glidein_client_dir/*prepare-hook* | tr '\n' ' ')"
     for search_path in $glidein_group_dir/{prepare-hook,itb-prepare-hook,itb-prepare-hook-lib}; do
         if [[ -e $search_path ]]; then
             hook_path=$search_path

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=749
+OSG_GLIDEIN_VERSION=756
 #######################################################################
 
 
@@ -313,9 +313,14 @@ advertise HAS_unsquashfs "$HAS_unsquashfs" "C"
 
 # check for locally cached .sif images - this will be helpful when determining 
 # we want to disable Singularity if CVMFS is not available
+# while we're at it, advertise the size
 GWMS_SINGULARITY_CACHED_IMAGES=$( (cd images/ && ls *.sif | sort | paste -d, -s) 2>/dev/null)
 if [[ "x$GWMS_SINGULARITY_CACHED_IMAGES" != "x" ]]; then
     advertise GWMS_SINGULARITY_CACHED_IMAGES "$GWMS_SINGULARITY_CACHED_IMAGES" "S"
+fi
+GWMS_SINGULARITY_CACHED_IMAGES_KB=$( (du -kc images/*.sif | tail -n 1 | awk '{print $1}') 2>/dev/null)
+if [[ "x$GWMS_SINGULARITY_CACHED_IMAGES_KB" != "x" ]]; then
+    advertise GWMS_SINGULARITY_CACHED_IMAGES_KB "$GWMS_SINGULARITY_CACHED_IMAGES_KB" "I"
 fi
 
 

--- a/ospool-pilot/main/pilot/default-image
+++ b/ospool-pilot/main/pilot/default-image
@@ -171,6 +171,8 @@ fi
 
 # source our helpers
 group_dir=$(get_glidein_config_value GLIDECLIENT_GROUP_WORK_DIR)
+client_dir=$(get_glidein_config_value GLIDECLIENT_WORK_DIR)
+cp -ns $client_dir/*ospool-lib $group_dir/ 2>/dev/null && echo "Linking helper(s) from $(ls $client_dir/*ospool-lib | tr '\n' ' ')" 1>&2
 if [ -e "$group_dir/itb-ospool-lib" ]; then
     source "$group_dir/itb-ospool-lib"
 else

--- a/ospool-pilot/main/pilot/singularity-extras
+++ b/ospool-pilot/main/pilot/singularity-extras
@@ -49,6 +49,8 @@ fi
 
 # source our helpers
 group_dir=$(get_glidein_config_value GLIDECLIENT_GROUP_WORK_DIR)
+client_dir=$(get_glidein_config_value GLIDECLIENT_WORK_DIR)
+cp -ns $client_dir/*ospool-lib $group_dir/ 2>/dev/null && info "Linking helper(s) from $(ls $client_dir/*ospool-lib | tr '\n' ' ')"
 if [ -e "$group_dir/itb-ospool-lib" ]; then
     source "$group_dir/itb-ospool-lib"
 else


### PR DESCRIPTION
Includes the following PRs and commits:

- 29b965d211529c7549c76a1872e46a8c70c2ef11 deal with Pelican advertising PelicanPluginVersion instead of PluginVersion
- d3916a55e3e0696e9f35a0fadcf57bfe792b4c63 use Pelican 7.8.1
- efe0d3a3b8d62135cff626995e28970324f3d422 fix some shellcheck quoting warnings
- b87cceff121e36f96b1dd1fb6eef18a7480987f8 advertise image cache size
- #298 INF-1890 Copy helper/hook scripts from frontend client dir if needed