### PR TITLE
Disable main-canary

### DIFF
--- a/ospool.osg-htc.org/production/frontend-template.xml
+++ b/ospool.osg-htc.org/production/frontend-template.xml
@@ -321,7 +321,7 @@
       </group>
 
       <!-- see OSPOOL-45 -->
-      <group name="main-canary" comment="Alternate main group for A/B testing" enabled="True">
+      <group name="main-canary" comment="Alternate main group for A/B testing" enabled="False">
          <config ignore_down_entries="">
             <glideins_removal margin="0" requests_tracking="False" type="NO" wait="0"/>
             <idle_glideins_lifetime max="864000"/>


### PR DESCRIPTION
We aren't using it right now and it's causing too many pilots to be sent to sites because the factory pilot cap is per FE group.