### PR TITLE
Fixed condor_userprio/negotiator auth

### DIFF
--- a/ospool.osg-htc.org/development/htcondor-config.d/95_security_osgflockgit.config
+++ b/ospool.osg-htc.org/development/htcondor-config.d/95_security_osgflockgit.config
@@ -6,7 +6,8 @@ SEC_TOKEN_ISSUER_KEY = flock.opensciencegrid.org
 
 CERTIFICATE_MAPFILE= /etc/condor/certs/condor_mapfile
 
-ALLOW_ADMINISTRATOR = condor@$(UID_DOMAIN) root@$(UID_DOMAIN) ospool@flock.opensciencegrid.org token-registry@flock.opensciencegrid.org token-registry-dev@flock.opensciencegrid.org
+# condor@password is required for condor_userprio/negotiator communication
+ALLOW_ADMINISTRATOR = condor@$(UID_DOMAIN) root@$(UID_DOMAIN) condor@password ospool@flock.opensciencegrid.org token-registry@flock.opensciencegrid.org token-registry-dev@flock.opensciencegrid.org
 
 # use our own SSL settings (gwms sets these earlier in the config)
 AUTH_SSL_CLIENT_CAFILE = /etc/pki/tls/certs/ca-bundle.crt

--- a/ospool.osg-htc.org/production/htcondor-config.d/95_security_osgflockgit.config
+++ b/ospool.osg-htc.org/production/htcondor-config.d/95_security_osgflockgit.config
@@ -6,7 +6,8 @@ SEC_TOKEN_ISSUER_KEY = flock.opensciencegrid.org
 
 CERTIFICATE_MAPFILE= /etc/condor/certs/condor_mapfile
 
-ALLOW_ADMINISTRATOR = condor@$(UID_DOMAIN) root@$(UID_DOMAIN) ospool@flock.opensciencegrid.org token-registry@flock.opensciencegrid.org token-registry-dev@flock.opensciencegrid.org
+# condor@password is required for condor_userprio/negotiator communication
+ALLOW_ADMINISTRATOR = condor@$(UID_DOMAIN) root@$(UID_DOMAIN) condor@password ospool@flock.opensciencegrid.org token-registry@flock.opensciencegrid.org token-registry-dev@flock.opensciencegrid.org
 
 # use our own SSL settings (gwms sets these earlier in the config)
 AUTH_SSL_CLIENT_CAFILE = /etc/pki/tls/certs/ca-bundle.crt


### PR DESCRIPTION
condor_userprio (from the CMs) to the negotiator uses pool password authentication, so this PM adds condor@password to the ADMINISTRATORS. This has been discussed with Jaime and BrianB.