### PR TITLE
Do not pass X509_USER_PROXY from the glidein to the job

### DIFF
--- a/ospool-pilot/itb-canary/pilot/additional-htcondor-config
+++ b/ospool-pilot/itb-canary/pilot/additional-htcondor-config
@@ -418,7 +418,6 @@ for envvar in \
      http_proxy \
      https_proxy \
      FTP_PROXY \
-     X509_USER_PROXY \
 ; do
 
 if [ ! -z ${!envvar+x} ]; then

--- a/ospool-pilot/itb/pilot/additional-htcondor-config
+++ b/ospool-pilot/itb/pilot/additional-htcondor-config
@@ -418,7 +418,6 @@ for envvar in \
      http_proxy \
      https_proxy \
      FTP_PROXY \
-     X509_USER_PROXY \
 ; do
 
 if [ ! -z ${!envvar+x} ]; then

--- a/ospool-pilot/main-canary/pilot/additional-htcondor-config
+++ b/ospool-pilot/main-canary/pilot/additional-htcondor-config
@@ -418,7 +418,6 @@ for envvar in \
      http_proxy \
      https_proxy \
      FTP_PROXY \
-     X509_USER_PROXY \
 ; do
 
 if [ ! -z ${!envvar+x} ]; then

--- a/ospool-pilot/main/pilot/additional-htcondor-config
+++ b/ospool-pilot/main/pilot/additional-htcondor-config
@@ -418,7 +418,6 @@ for envvar in \
      http_proxy \
      https_proxy \
      FTP_PROXY \
-     X509_USER_PROXY \
 ; do
 
 if [ ! -z ${!envvar+x} ]; then


### PR DESCRIPTION
This is for LIGO. OSPool is not affected as we do not do X509 auth for the glideins anymore.