### PR TITLE
Removing group quotas

### DIFF
--- a/ospool.osg-htc.org/development/htcondor-config.d/95_priorties_osgflockgit.config
+++ b/ospool.osg-htc.org/development/htcondor-config.d/95_priorties_osgflockgit.config
@@ -6,31 +6,5 @@ REMOTE_PRIO_FACTOR = 1000
 # half-life for real user priority
 PRIORITY_HALFLIFE = 21600
 
-GROUP_NAMES = \
-              group_xsedehigh
-
-#              group_xsedelow, \
-#              group_opportunistic
-
-# and jobs not having a group are jobs flocking
-
-#GROUP_QUOTA_DYNAMIC_group_mitlns = .35
-GROUP_QUOTA_DYNAMIC_group_xsedehigh = .20
-
-#GROUP_QUOTA_DYNAMIC_group_xsedelow = .15
-#GROUP_QUOTA_DYNAMIC_group_opportunistic = .35
-
 GROUP_ACCEPT_SURPLUS = True
-
-# Default: ifThenElse(AccountingGroup=?="<none>",3.4e+38,ifThenElse(GroupQuota>0,GroupResourcesInUse/GroupQuota,3.3e+38))
-
-# randomly put the <none> group first to prevent starvation from flocking hosts
-#GROUP_SORT_EXPR = ifThenElse(AccountingGroup =?= "<none>", \
-#                             ifThenElse(random(100) < 1, 0, 1e+30), \
-#                             ifThenElse(GroupQuota > 0, GroupResourcesInUse/GroupQuota, 1e+20))
-
-# promise N slots to flocking hosts
-#GROUP_SORT_EXPR = ifThenElse(AccountingGroup =?= "<none>", \
-#                             GroupResourcesInUse/2000.0, \
-#                             ifThenElse(GroupQuota > 0, GroupResourcesInUse/GroupQuota, 1e+20))
 

--- a/ospool.osg-htc.org/production/htcondor-config.d/95_priorties_osgflockgit.config
+++ b/ospool.osg-htc.org/production/htcondor-config.d/95_priorties_osgflockgit.config
@@ -6,31 +6,5 @@ REMOTE_PRIO_FACTOR = 1000
 # half-life for real user priority
 PRIORITY_HALFLIFE = 21600
 
-GROUP_NAMES = \
-              group_xsedehigh
-
-#              group_xsedelow, \
-#              group_opportunistic
-
-# and jobs not having a group are jobs flocking
-
-#GROUP_QUOTA_DYNAMIC_group_mitlns = .35
-GROUP_QUOTA_DYNAMIC_group_xsedehigh = .20
-
-#GROUP_QUOTA_DYNAMIC_group_xsedelow = .15
-#GROUP_QUOTA_DYNAMIC_group_opportunistic = .35
-
 GROUP_ACCEPT_SURPLUS = True
-
-# Default: ifThenElse(AccountingGroup=?="<none>",3.4e+38,ifThenElse(GroupQuota>0,GroupResourcesInUse/GroupQuota,3.3e+38))
-
-# randomly put the <none> group first to prevent starvation from flocking hosts
-#GROUP_SORT_EXPR = ifThenElse(AccountingGroup =?= "<none>", \
-#                             ifThenElse(random(100) < 1, 0, 1e+30), \
-#                             ifThenElse(GroupQuota > 0, GroupResourcesInUse/GroupQuota, 1e+20))
-
-# promise N slots to flocking hosts
-#GROUP_SORT_EXPR = ifThenElse(AccountingGroup =?= "<none>", \
-#                             GroupResourcesInUse/2000.0, \
-#                             ifThenElse(GroupQuota > 0, GroupResourcesInUse/GroupQuota, 1e+20))
 


### PR DESCRIPTION
This PR removes old group quota configs from the CMs. This was determined to be an issue during a debugging session this morning, where the negotiator stopped scheduling because a quota surplus. The XSEDE group has not been used for years.