### PR TITLE
main 771: drop OSG_CPU_MODEL and OSGVO_CPU_MODEL attributes

### DIFF
--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=770
+OSG_GLIDEIN_VERSION=771
 #######################################################################
 
 

--- a/ospool-pilot/main/pilot/advertise-userenv
+++ b/ospool-pilot/main/pilot/advertise-userenv
@@ -220,11 +220,6 @@ advertise OSGVO_OS_VERSION "$OS_VERSION" "S"
 advertise OSGVO_OS_STRING "$OS_NAME $OS_VERSION" "S"
 advertise OSGVO_OS_KERNEL "$OS_KERNEL" "S"
 
-# cpu info
-CPU_MODEL=`cat /proc/cpuinfo | grep -i "^model name" | head -n 1 | sed -r 's/[a-zA-Z \t]+:[ ]*//'`
-advertise OSG_CPU_MODEL "$CPU_MODEL" "S"
-advertise OSGVO_CPU_MODEL "$CPU_MODEL" "S"
-
 # some cpu flags HTCondor is not yet advertising
 for FLAG in `cat /proc/cpuinfo | egrep -i ^flags | head -n 1 | sed -r 's/[a-zA-Z \t]+:[ ]*//'`; do
     if (echo "$FLAG" | egrep "avx512|cx16|f16c") >/dev/null 2>&1; then


### PR DESCRIPTION
They aren't used and the way we get them doesn't work on ARM. If we need to add them back, parse the output of `lscpu` instead of `/proc/cpuinfo`.