### PR TITLE
Removed UCSD factories - they will be go away Oct 1

### DIFF
--- a/ospool.osg-htc.org/development/frontend-template.xml
+++ b/ospool.osg-htc.org/development/frontend-template.xml
@@ -35,7 +35,6 @@
          <match_attrs>
          </match_attrs>
          <collectors>
-            <collector DN="/DC=org/DC=incommon/C=US/ST=Wisconsin/L=Madison/O=University of Wisconsin-Madison/OU=OCIS/CN=gfactory-itb-1.opensciencegrid.org" factory_identity="gfactory@gfactory-itb-1.opensciencegrid.org" my_identity="feosgospool@gfactory-itb-1.opensciencegrid.org" node="gfactory-itb-1.opensciencegrid.org"/>
             <collector DN="/CN=gfactory-itb-1.osg-htc.org" factory_identity="gfactory@gfactory-itb-1.osg-htc.org" my_identity="feosgospool@gfactory-itb-1.osg-htc.org" node="gfactory-itb-1.osg-htc.org"/>
          </collectors>
       </factory>

--- a/ospool.osg-htc.org/production/frontend-template.xml
+++ b/ospool.osg-htc.org/production/frontend-template.xml
@@ -64,7 +64,6 @@
          </match_attrs>
          <collectors>
             <collector DN="/CN=gfactory-1.osg-htc.org" factory_identity="gfactory@gfactory-1.osg-htc.org" my_identity="feosgospool@gfactory-1.osg-htc.org" node="gfactory-1.osg-htc.org"/>
-            <collector DN="/DC=org/DC=incommon/C=US/ST=Wisconsin/L=Madison/O=University of Wisconsin-Madison/OU=OCIS/CN=gfactory-2.opensciencegrid.org" factory_identity="gfactory@gfactory-2.opensciencegrid.org" my_identity="feosgospool@gfactory-2.opensciencegrid.org" node="gfactory-2.opensciencegrid.org"/>
          </collectors>
       </factory>
       <job comment="Define job constraint and schedds globally for simplicity, on CHTC, only count jobs which wants glideins"


### PR DESCRIPTION
From the factory team:

> Now that all the Frontends are registered to the Kubernetes based OSG
> Tiger factory, we are planning to shut off the UCSD factory next
> Tuesday, October 1st. Longer term we will have a second k8s factory
> hosted in the OSG Tempest cluster for added redundancy.