### PR TITLE
ITB: Initial aarch64 support

### DIFF
--- a/ospool-pilot/itb/lib/ospool-lib
+++ b/ospool-pilot/itb/lib/ospool-lib
@@ -153,8 +153,14 @@ function check_singularity_sif_support {
 
     # Grab an alpine image from somewhere; ok to download each time since
     # it's like 3 megs
-    local cvmfs_alpine="/cvmfs/oasis.opensciencegrid.org/osg/projects/OSG-Staff/images/library__alpine__latest.sif"
-    local static_registry_alpine="docker://ospool-static-registry.osg.chtc.io/alpine:latest"
+    local arch=$(uname -m)
+    local cvmfs_alpine="/cvmfs/oasis.opensciencegrid.org/osg/projects/OSG-Staff/images/$arch/library__alpine__latest.sif"
+    # temporary seperation until we decide on longterm multi-arch hosting
+    if [ "X$arch" = "Xx86_64" ]; then
+        local static_registry_alpine="docker://ospool-static-registry.osg.chtc.io/alpine:latest"
+    else
+        local static_registry_alpine="docker://hub.opensciencegrid.org/htc/minimal:0"
+    fi
     local sylabs_alpine="library://alpine:3"
     local work_dir=$(get_glidein_config_value GLIDEIN_WORK_DIR)
     local image_dir="$work_dir/../images"
@@ -219,7 +225,13 @@ function check_singularity_registry_support {
     # unpack it into a temporary sandbox first, nonzero otherwise.
     # This also tests building a SIF from a registry image
     #
-    local static_registry_alpine="docker://ospool-static-registry.osg.chtc.io/alpine:latest"
+    local arch=$(uname -m)
+    # temporary seperation until we decide on longterm multi-arch hosting
+    if [ "X$arch" = "Xx86_64" ]; then
+        local static_registry_alpine="docker://ospool-static-registry.osg.chtc.io/alpine:latest"
+    else
+        local static_registry_alpine="docker://hub.opensciencegrid.org/htc/minimal:0"
+    fi
     local has_singularity=$(get_glidein_config_value HAS_SINGULARITY)
     local singularity_path=$(get_glidein_config_value GWMS_SINGULARITY_PATH)
 

--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=775
+OSG_GLIDEIN_VERSION=776
 #######################################################################
 
 

--- a/ospool-pilot/itb/pilot/default-image
+++ b/ospool-pilot/itb/pilot/default-image
@@ -46,6 +46,8 @@ function determine_default_container_image {
         OSG_DEFAULT_CONTAINER_DISTRIBUTION=`get_glidein_config_value OSG_DEFAULT_CONTAINER_DISTRIBUTION_GPU`
     fi
 
+    arch=$(uname -m)
+
     SELECTED_IMAGE=""
     if [ "x$OSG_DEFAULT_CONTAINER_DISTRIBUTION" != "x" ]; then
         # new style - weighted random selection
@@ -70,6 +72,11 @@ function determine_default_container_image {
         else
             SELECTED_IMAGE="htc/rocky:9"
         fi
+    fi
+
+    # temp for arm until we get the image repos/syncing in place
+    if [ "X$arch" = "Xaarch64" ]; then
+        SELECTED_IMAGE="htc/arm:test"
     fi
 
     # Should we use CVMFS or pull images directly?
@@ -100,6 +107,12 @@ function determine_default_container_image {
     # the images dir is required here, as we want to keep a copy of the image for this test
     if check_singularity_sif_support; then
         singularity_can_use_sif=1
+    fi
+
+    # temp for arm until we get the image repos/syncing in place
+    if [ "X$arch" = "Xaarch64" ]; then
+        # have to pull, cvmfs sync is not yet ready
+        pull_images=1
     fi
 
     if [[ $pull_images -ge 0 ]]; then
@@ -135,8 +148,8 @@ function determine_default_container_image {
         IMAGE_NAME=$(echo "$SELECTED_IMAGE" | sed 's;[:/];__;g')
         IMAGE_PATH=$PWD/images/$IMAGE_NAME.sif
         WEEK=$(date +'%V')
-        OSDF_URL=osdf:///ospool/uc-shared/public/OSG-Staff/images/$WEEK/sif/$IMAGE_NAME.sif
-        HTTP_URL=http://ospool-images.osgprod.tempest.chtc.io/$WEEK/sif/$IMAGE_NAME.sif
+        OSDF_URL=osdf:///ospool/uc-shared/public/OSG-Staff/images/$WEEK/$arch/$IMAGE_NAME.sif
+        HTTP_URL=http://ospool-images.osgprod.tempest.chtc.io/$WEEK/$arch/$IMAGE_NAME.sif
         (osdf_download $IMAGE_PATH $OSDF_URL \
             || http_download $IMAGE_PATH $HTTP_URL \
             || singularity pull --force $IMAGE_PATH docker://hub.opensciencegrid.org/$SELECTED_IMAGE) >$IMAGE_PATH.log 2>&1


### PR DESCRIPTION
Adds initial aarch64 support for our glideins. This is partially a temporary solution while we wait for multiarch Docker/CVMFS syncing. Note:

1. After briefly looking at `ospool-static-registry`, I don't think we can do multiarch images there. We should discuss what a long-term pulling source should be. This PR will use OSG Harbor for non-x86_64 architectures, and keep the static registry for x86_64 glideins.
2.  Until the Docker/CVMFS syncing has multiarch, ARM glideins will default to always pull images.