### PR TITLE
CUDA_VISIBLE_DEVICES is not limited to ints

### DIFF
--- a/ospool-pilot/itb/pilot/default-image
+++ b/ospool-pilot/itb/pilot/default-image
@@ -38,11 +38,11 @@ function determine_default_container_image {
 
     # if we are given GPUs, pick up GPU specific images
     # make sure CUDA_VISIBLE_DEVICES is set to something sane - we
-    # have seen values like "na", -1 and x10000
+    # have seen values like "na", -1 and 10000
     if [ -n "$CUDA_VISIBLE_DEVICES" ] && \
-       [ "$CUDA_VISIBLE_DEVICES" -eq "$CUDA_VISIBLE_DEVICES" ] 2>/dev/null && \
-       [ "$CUDA_VISIBLE_DEVICES" -gt 0 ] && \
-       [ "$CUDA_VISIBLE_DEVICES" -lt 50 ] ; then
+       [ "$CUDA_VISIBLE_DEVICES" != "na" ] && \
+       [ "$CUDA_VISIBLE_DEVICES" != "-1" ] && \
+       [ "$CUDA_VISIBLE_DEVICES" != "10000" ] ; then
         OSG_DEFAULT_CONTAINER_DISTRIBUTION=`get_glidein_config_value OSG_DEFAULT_CONTAINER_DISTRIBUTION_GPU`
     fi
 

--- a/ospool-pilot/main/pilot/default-image
+++ b/ospool-pilot/main/pilot/default-image
@@ -38,11 +38,11 @@ function determine_default_container_image {
 
     # if we are given GPUs, pick up GPU specific images
     # make sure CUDA_VISIBLE_DEVICES is set to something sane - we
-    # have seen values like "na", -1 and x10000
+    # have seen values like "na", -1 and 10000
     if [ -n "$CUDA_VISIBLE_DEVICES" ] && \
-       [ "$CUDA_VISIBLE_DEVICES" -eq "$CUDA_VISIBLE_DEVICES" ] 2>/dev/null && \
-       [ "$CUDA_VISIBLE_DEVICES" -gt 0 ] && \
-       [ "$CUDA_VISIBLE_DEVICES" -lt 50 ] ; then
+       [ "$CUDA_VISIBLE_DEVICES" != "na" ] && \
+       [ "$CUDA_VISIBLE_DEVICES" != "-1" ] && \
+       [ "$CUDA_VISIBLE_DEVICES" != "10000" ] ; then
         OSG_DEFAULT_CONTAINER_DISTRIBUTION=`get_glidein_config_value OSG_DEFAULT_CONTAINER_DISTRIBUTION_GPU`
     fi
 


### PR DESCRIPTION
This part of the code wrongly assumed that CUDA_VISIBLE_DEVICES could only take on integer values, but in fact it can be named devices (`GPU-68821ed8`) or list of devices (`GPU-68821ed8, GPU-68821ed9`). We still have to exclude some magic strings/numbers used to indicate that no GPUs are available.