### PR TITLE
SOFTAWRE-5872: rename rpm, replace in-text references to osg-flock (keep file paths the same)

### DIFF
--- a/node-check/osgvo-node-advertise
+++ b/node-check/osgvo-node-advertise
@@ -204,7 +204,7 @@ find . -maxdepth 1 -name $TEST_FILE_4H.\* -mmin +240 -exec rm {} \;
 find . -maxdepth 1 -name adv-singularity-work.\* -mmin +240 -exec rm -rf {} \;
 
 if [ "x$OSG_SINGULARITY_REEXEC" = "x" ]; then
-    info "This is a setup script for the OSG-FLOCK frontend."
+    info "This is a setup script for the OSPOOL-AP frontend."
     info "In case of problems, contact Mats Rynge (rynge@isi.edu)"
     info "Running in directory $PWD"
     

--- a/ospool-pilot/itb/pilot/advertise-userenv
+++ b/ospool-pilot/itb/pilot/advertise-userenv
@@ -91,7 +91,7 @@ find . -maxdepth 1 -name $TEST_FILE_1H.\* -mmin +60 -exec rm {} \;
 find . -maxdepth 1 -name $TEST_FILE_4H.\* -mmin +240 -exec rm {} \;
 find . -maxdepth 1 -name adv-singularity-work.\* -mmin +240 -exec rm -rf {} \;
 
-info "This is a setup script for the OSG-FLOCK frontend."
+info "This is a setup script for the OSPOOL-AP frontend."
 info "In case of problems, contact Mats Rynge (rynge@isi.edu)"
 info "Running in directory $PWD"
     

--- a/ospool-pilot/main/pilot/advertise-userenv
+++ b/ospool-pilot/main/pilot/advertise-userenv
@@ -91,7 +91,7 @@ find . -maxdepth 1 -name $TEST_FILE_1H.\* -mmin +60 -exec rm {} \;
 find . -maxdepth 1 -name $TEST_FILE_4H.\* -mmin +240 -exec rm {} \;
 find . -maxdepth 1 -name adv-singularity-work.\* -mmin +240 -exec rm -rf {} \;
 
-info "This is a setup script for the OSG-FLOCK frontend."
+info "This is a setup script for the OSPOOL-AP frontend."
 info "In case of problems, contact Mats Rynge (rynge@isi.edu)"
 info "Running in directory $PWD"
     

--- a/ospool-pilot/old/pilot/advertise-userenv
+++ b/ospool-pilot/old/pilot/advertise-userenv
@@ -91,7 +91,7 @@ find . -maxdepth 1 -name $TEST_FILE_1H.\* -mmin +60 -exec rm {} \;
 find . -maxdepth 1 -name $TEST_FILE_4H.\* -mmin +240 -exec rm {} \;
 find . -maxdepth 1 -name adv-singularity-work.\* -mmin +240 -exec rm -rf {} \;
 
-info "This is a setup script for the OSG-FLOCK frontend."
+info "This is a setup script for the OSPOOL-AP frontend."
 info "In case of problems, contact Mats Rynge (rynge@isi.edu)"
 info "Running in directory $PWD"
     

--- a/rpm/osg-flock.spec
+++ b/rpm/osg-flock.spec
@@ -1,6 +1,6 @@
 Name:      osg-flock
 Version:   1.9
-Release:   2%{?dist}
+Release:   3%{?dist}
 Summary:   OSG configurations for a flocking host
 
 License:   Apache 2.0

--- a/rpm/ospool-ap.spec
+++ b/rpm/ospool-ap.spec
@@ -1,6 +1,6 @@
 Name:      ospool-ap
 Version:   1.9
-Release:   3%{?dist}
+Release:   4%{?dist}
 Summary:   OSG configurations for a flocking host
 
 License:   Apache 2.0
@@ -71,7 +71,7 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
-* Mon Oct 21 2024 Matt Westphall <westphall@wisc.edu> - 1.9-3
+* Mon Oct 21 2024 Matt Westphall <westphall@wisc.edu> - 1.9-4
 - Initial release as ospool-ap
 
 * Tue Feb 21 2023 Mats Rynge <rynge@isi.edu> - 1.9-1

--- a/rpm/ospool-ap.spec
+++ b/rpm/ospool-ap.spec
@@ -1,16 +1,19 @@
-Name:      osg-flock
+Name:      ospool-ap
 Version:   1.9
 Release:   3%{?dist}
 Summary:   OSG configurations for a flocking host
 
 License:   Apache 2.0
-URL:       https://opensciencegrid.org/docs/submit/osg-flock
+URL:       https://opensciencegrid.org/docs/submit/ospool-ap
 
 BuildArch: noarch
 
 Requires(post): gratia-probe-condor-ap
 BuildRequires: condor
 Requires: condor
+
+Obsoletes: osg-flock <= %{version}
+Provides: osg-flock = %{version}
 
 Source0: %{name}-%{version}%{?gitrev:-%{gitrev}}.tar.gz
 
@@ -68,6 +71,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Mon Oct 21 2024 Matt Westphall <westphall@wisc.edu> - 1.9-3
+- Initial release as ospool-ap
+
 * Tue Feb 21 2023 Mats Rynge <rynge@isi.edu> - 1.9-1
 - Add OSPool attribute to the job ad from the EP config (SOFTWARE-4803)
 

--- a/wip-node-check/osgvo-advertise-userenv
+++ b/wip-node-check/osgvo-advertise-userenv
@@ -91,7 +91,7 @@ find . -maxdepth 1 -name $TEST_FILE_1H.\* -mmin +60 -exec rm {} \;
 find . -maxdepth 1 -name $TEST_FILE_4H.\* -mmin +240 -exec rm {} \;
 find . -maxdepth 1 -name adv-singularity-work.\* -mmin +240 -exec rm -rf {} \;
 
-info "This is a setup script for the OSG-FLOCK frontend."
+info "This is a setup script for the OSPOOL-AP frontend."
 info "In case of problems, contact Mats Rynge (rynge@isi.edu)"
 info "Running in directory $PWD"
     


### PR DESCRIPTION
- Committed on top of the last release (1.9.3). Merge conflict since there appears to be a 1.10 release noted in the spec file that was never released. Do we want to wrap that into this release or handle it separately? 
