### PR TITLE
main 789: use Pelican from the condor tarball

### DIFF
--- a/ospool-pilot/main/pilot/additional-htcondor-config
+++ b/ospool-pilot/main/pilot/additional-htcondor-config
@@ -314,7 +314,7 @@ fi
 #
 # If set to "condor", it will use what's in the Condor tarball.  (This can be
 # used to override a non-Condor default.)
-DEFAULT_DOWNLOAD_PELICAN_VERSION=7.11.2
+DEFAULT_DOWNLOAD_PELICAN_VERSION=condor
 
 if [[ ! $DOWNLOAD_PELICAN_VERSION ]]; then
     DOWNLOAD_PELICAN_VERSION=$(gconfig_get DOWNLOAD_PELICAN_VERSION)

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=788
+OSG_GLIDEIN_VERSION=789
 #######################################################################
 
 


### PR DESCRIPTION
The condor devs would prefer if we used the OSDF plugin that was shipped with the Condor tarball instead of downloading our own, at least in production.  (We should keep downloading the tarball in ITB so we can test new versions.)