### PR TITLE
Lehigh - Hawk is causing a 'Forbidden' error message on stageout.

### DIFF
--- a/ospool-pilot/main/pilot/additional-htcondor-config
+++ b/ospool-pilot/main/pilot/additional-htcondor-config
@@ -342,7 +342,8 @@ if [[ $OSDF_PLUGIN ]]; then
     # MI-HORUS: email 4/14/25 - temp disabled for OSDF debugging
     # MSU-DataMachine: email 4/14/25 - temp disabled for OSDF debugging
     # USD-Lawrence: email 4/15/25 - temp disabled for OSDF debugging
-    if (echo "$glidein_site" | grep -E "UA Little Rock ITS|MI-HORUS|MSU-DataMachine|USD-Lawrence") >/dev/null 2>&1; then
+    # Lehigh - Hawk: observed failures on stageout due to 403 Forbidden.  Emailed 4/23/25; B. Lin is debugging. -- BB
+    if (echo "$glidein_site" | grep -E "UA Little Rock ITS|MI-HORUS|MSU-DataMachine|USD-Lawrence|Lehigh") >/dev/null 2>&1; then
         OSDF_FAIL_REASON="Stash/OSDF plugin explicitly disabled at site $glidein_site"
     else
         if osdf_plugin_is_ok "$OSDF_PLUGIN"; then


### PR DESCRIPTION
It is not clear what causes this error or why it's site-specific (the version of Pelican at this site, for example, is the same as at others).

However, it's clear that there's a quite high error rate for AP20/21 due to this.

Until we've debugged it, disabling the site in main.  Purposely leaving it enabled in ITB so @brianhlin can continue debugging.

@rynge @brianhlin @osg-cat 