### PR TITLE
Add ara.opensciencegrid.org CVMFS check for IceCube

### DIFF
--- a/node-check/osgvo-node-advertise
+++ b/node-check/osgvo-node-advertise
@@ -354,6 +354,7 @@ if [ "x$OSG_SINGULARITY_REEXEC" = "x" ]; then
        ams.cern.ch \
        atlas.cern.ch \
        cms.cern.ch \
+       ara.opensciencegrid.org \
        connect.opensciencegrid.org \
        eic.opensciencegrid.org \
        gwosc.osgstorage.org \

--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -374,6 +374,7 @@ for FS in \
    belle.cern.ch \
    clicdp.cern.ch \
    cms.cern.ch \
+   ara.opensciencegrid.org \
    connect.opensciencegrid.org \
    eic.opensciencegrid.org \
    gluex.osgstorage.org \

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -374,6 +374,7 @@ for FS in \
    belle.cern.ch \
    clicdp.cern.ch \
    cms.cern.ch \
+   ara.opensciencegrid.org \
    connect.opensciencegrid.org \
    eic.opensciencegrid.org \
    gluex.osgstorage.org \


### PR DESCRIPTION
The IceCube FE is still using the `node-check/osgvo-node-advertise`, so that might be the only place this is necessary, but I think they also flock to the OSPool, so maybe it doesn't hurt to have it there, too.