### PR TITLE
Removed catch-22 call to check_singularity_sif_support

### DIFF
--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=838
+OSG_GLIDEIN_VERSION=839
 #######################################################################
 
 

--- a/ospool-pilot/itb/pilot/default-image
+++ b/ospool-pilot/itb/pilot/default-image
@@ -162,11 +162,6 @@ function determine_default_container_image {
     elif (echo "x$entry_name" | egrep "OSG_CHTC-canary2|Syracuse|Nebraska") >/dev/null 2>&1; then
         info "Not allowing non-CVMFS images, as the site is on the deny list ($entry_name)"
         pull_images=0
-    elif ! check_singularity_sif_support; then
-        # Forbid running non-CVMFS images if they have to be unpacked first.
-        # May change later if we find sites where this is "safe."
-        info "Not allowing non-CVMFS images, as Singularity cannot directly run SIF files"
-        pull_images=0
     fi
 
     if [ $pull_images = 1 ]; then

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=833
+OSG_GLIDEIN_VERSION=834
 #######################################################################
 
 

--- a/ospool-pilot/main/pilot/default-image
+++ b/ospool-pilot/main/pilot/default-image
@@ -162,11 +162,6 @@ function determine_default_container_image {
     elif (echo "x$entry_name" | egrep "OSG_CHTC-canary2|Syracuse|Nebraska") >/dev/null 2>&1; then
         info "Not allowing non-CVMFS images, as the site is on the deny list ($entry_name)"
         pull_images=0
-    elif ! check_singularity_sif_support; then
-        # Forbid running non-CVMFS images if they have to be unpacked first.
-        # May change later if we find sites where this is "safe."
-        info "Not allowing non-CVMFS images, as Singularity cannot directly run SIF files"
-        pull_images=0
     fi
 
     if [ $pull_images = 1 ]; then


### PR DESCRIPTION
Removes a call to `check_singularity_sif_support` which happens too early - we don't know which Apptainer to use at that point, so the test is not reliable. The function is called later (at the appropriate place in the Apptainer detection/configuration) in `singularity-extras`, so the attributes will still be set.