### PR TITLE
Relax IsBlackHole, especially for large-core-count machines

### DIFF
--- a/ospool-pilot/itb/pilot/additional-htcondor-config
+++ b/ospool-pilot/itb/pilot/additional-htcondor-config
@@ -82,7 +82,7 @@ gconfig_add STATISTICS_TO_PUBLISH_LIST "JobDuration, JobBusyTime"
 add_condor_vars_line STATISTICS_TO_PUBLISH_LIST "C" "-" "+" "N" "N" "-"
 
 # black holes, oh my (https://opensciencegrid.atlassian.net/browse/OSPOOL-3)
-gconfig_add IsBlackHole "IfThenElse(RecentJobDurationAvg is undefined, false, RecentJobDurationCount >= 10 && RecentJobDurationAvg < 180)"
+gconfig_add IsBlackHole "IfThenElse(RecentJobDurationAvg is undefined, false, RecentJobDurationCount >= TotalCPUs && RecentJobDurationAvg < 60)"
 add_condor_vars_line IsBlackHole "C" "-" "+" "N" "Y" "-"
 
 # excessive load, probably due to swapping (https://opensciencegrid.atlassian.net/browse/OSPOOL-2)

--- a/ospool-pilot/main/pilot/additional-htcondor-config
+++ b/ospool-pilot/main/pilot/additional-htcondor-config
@@ -82,7 +82,7 @@ gconfig_add STATISTICS_TO_PUBLISH_LIST "JobDuration, JobBusyTime"
 add_condor_vars_line STATISTICS_TO_PUBLISH_LIST "C" "-" "+" "N" "N" "-"
 
 # black holes, oh my (https://opensciencegrid.atlassian.net/browse/OSPOOL-3)
-gconfig_add IsBlackHole "IfThenElse(RecentJobDurationAvg is undefined, false, RecentJobDurationCount >= 10 && RecentJobDurationAvg < 180)"
+gconfig_add IsBlackHole "IfThenElse(RecentJobDurationAvg is undefined, false, RecentJobDurationCount >= TotalCPUs && RecentJobDurationAvg < 60)"
 add_condor_vars_line IsBlackHole "C" "-" "+" "N" "Y" "-"
 
 # excessive load, probably due to swapping (https://opensciencegrid.atlassian.net/browse/OSPOOL-2)


### PR DESCRIPTION
Some of our large core count machines are getting falsely labeled as black holes because `IsBlackHole` uses a fixed limit. The PR also relaxes the average runtime to 60 seconds. It can be argued that we should discourage short jobs, but effectively DOS the startd for all users is not a good approach. Also, we will see a lot of short jobs next week during the OSG School.

The following command shows the scope of the issue:

    condor_status -const 'IsBlackHole && SlotType == "Partitionable"' -af:h Machine TotalCPUs CPUs Memory Disk IsBlackHole RecentJobDurationCount RecentJobDurationAvg

There might be some true black holes in there, such as `Purdue-Geddes`. I will be working on those - this PR would not change that detection.