### PR TITLE
NEGOTIATOR_SLOT_CONSTRAINT updates

### DIFF
--- a/ospool.osg-htc.org/development/htcondor-config.d/95_negotiator_osgflockgit.config
+++ b/ospool.osg-htc.org/development/htcondor-config.d/95_negotiator_osgflockgit.config
@@ -52,18 +52,27 @@ VALID_SPOOL_FILES=$(VALID_SPOOL_FILES), negotiator_allocated
 ENOUGH_MIPS = (Mips > 11800)
 
 # Make sure each negotiator considers the right set of slots.
-NEGOTIATOR_SLOT_CONSTRAINT = $(ENOUGH_MIPS) && OSPool =?= True && versioncmp(split(CondorVersion)[1],"9.6.0") >= 0
+NEGOTIATOR_SLOT_CONSTRAINT = $(ENOUGH_MIPS) && \
+                             versioncmp(split(CondorVersion)[1],"23.0.0") >= 0 && \
+                             (isUndefined(PelicanPluginVersion) || versioncmp(PelicanPluginVersion,"7.13.0") >= 0) && \
+                             isUndefined(GLIDEIN_ResourceName) != True && \
+                             GLIDEIN_ResourceName != "UNKNOWN" && \
+                             isUndefined(GLIDEIN_Site) != True && \
+                             GLIDEIN_Site != "UNKNOWN"
 
-# Allocated resoruces do not set OSPool=True
-NEGOTIATOR_ALLOCATED.NEGOTIATOR_SLOT_CONSTRAINT = OSPool =!= True
+# Allocated is not valid on ITB
+NEGOTIATOR_ALLOCATED.NEGOTIATOR_SLOT_CONSTRAINT = False
 
-# blacklist certain users
-#NEGOTIATOR_SUBMITTER_CONSTRAINT = Name != "ataffard@uclhc-1.ps.uci.edu"
-NEGOTIATOR_SUBMITTER_CONSTRAINT = True
+# blacklist certain users, protect the pool
+NEGOTIATOR_SUBMITTER_CONSTRAINT = (isUndefined(RecentJobsExitException) || RecentJobsExitException <= 20) && \
+                                  (isUndefined(RecentJobsNotStarted) || RecentJobsNotStarted <= 40)
 NEGOTIATOR_ALLOCATED.NEGOTIATOR_SUBMITTER_CONSTRAINT = $(NEGOTIATOR_SUBMITTER_CONSTRAINT)
+
+# limit what type of jobs we are willing to schedule
+# 2023-05-25 OSDF issue - stop scheduling such jobs for now
+# NOTE: Do not use TransferInput in the expression - it will cause an autoclusters explosion
+#NEGOTIATOR_JOB_CONSTRAINT = (regexp("osdf|stash", TransferInput) || regexp("osdf|stash", TransferOutputRemaps)) =!= True || ProjectName == "OSG-Staff"
 
 # maintenance
 #NEGOTIATOR_SLOT_CONSTRAINT = False
 #NEGOTIATOR_ALLOCATED.NEGOTIATOR_SLOT_CONSTRAINT = False
-
-

--- a/ospool.osg-htc.org/production/htcondor-config.d/95_negotiator_osgflockgit.config
+++ b/ospool.osg-htc.org/production/htcondor-config.d/95_negotiator_osgflockgit.config
@@ -60,14 +60,22 @@ ENOUGH_MIPS = (Mips > 11800)
 # Make sure each negotiator considers the right set of slots.
 NEGOTIATOR_SLOT_CONSTRAINT = $(ENOUGH_MIPS) && \
                              OSPool =?= True && \
-                             versioncmp(split(CondorVersion)[1],"9.6.0") >= 0 && \
-                             (isUndefined(PelicanPluginVersion) || versioncmp(PelicanPluginVersion,"7.11.0") >= 0) && \
-                             (isUndefined(OSDF_PLUGIN_VERSION) || versioncmp(OSDF_PLUGIN_VERSION,"7.11.0") >= 0) && \
+                             versioncmp(split(CondorVersion)[1],"23.0.0") >= 0 && \
+                             (isUndefined(PelicanPluginVersion) || versioncmp(PelicanPluginVersion,"7.13.0") >= 0) && \
                              isUndefined(GLIDEIN_ResourceName) != True && \
-                             GLIDEIN_ResourceName != "UNKNOWN"
+                             GLIDEIN_ResourceName != "UNKNOWN" && \
+                             isUndefined(GLIDEIN_Site) != True && \
+                             GLIDEIN_Site != "UNKNOWN"
 
 # Allocated resoruces do not set OSPool=True
-NEGOTIATOR_ALLOCATED.NEGOTIATOR_SLOT_CONSTRAINT = OSPool =!= True
+NEGOTIATOR_ALLOCATED.NEGOTIATOR_SLOT_CONSTRAINT = \
+                             OSPool =!= True && \
+                             versioncmp(split(CondorVersion)[1],"23.0.0") >= 0 && \
+                             (isUndefined(PelicanPluginVersion) || versioncmp(PelicanPluginVersion,"7.13.0") >= 0) && \
+                             isUndefined(GLIDEIN_ResourceName) != True && \
+                             GLIDEIN_ResourceName != "UNKNOWN" && \
+                             isUndefined(GLIDEIN_Site) != True && \
+                             GLIDEIN_Site != "UNKNOWN"
 
 # blacklist certain users, protect the pool
 NEGOTIATOR_SUBMITTER_CONSTRAINT = (isUndefined(RecentJobsExitException) || RecentJobsExitException <= 20) && \


### PR DESCRIPTION
1. Make sure `GLIDEIN_Site` is defined (like we already did for `GLIDEIN_ResourceName`)
2. Added exclusions to `Allocated` negotiator - we did not have the same protection on that as compared to the main negotiator.
3. Bumped minimum HTCondor version for glideins to 23.0.0
4. Bumped minimum Pelican plugin version to 7.13.0
5. Updated ITB config to mimic the production config