### PR TITLE
Expand disabled OSDF job expression to consider images

### DIFF
--- a/ospool.osg-htc.org/production/htcondor-config.d/95_negotiator_osgflockgit.config
+++ b/ospool.osg-htc.org/production/htcondor-config.d/95_negotiator_osgflockgit.config
@@ -78,8 +78,15 @@ NEGOTIATOR_SUBMITTER_CONSTRAINT = (isUndefined(RecentJobsExitException) || Recen
                                   (isUndefined(RecentJobsNotStarted) || RecentJobsNotStarted <= 40)
 NEGOTIATOR_ALLOCATED.NEGOTIATOR_SUBMITTER_CONSTRAINT = $(NEGOTIATOR_SUBMITTER_CONSTRAINT)
 
-# stop scheduling of all OSDF jobs (except OSG-Staff for debugging)
-#NEGOTIATOR_JOB_CONSTRAINT = regexp("osdf|stash|pelican", WantTransferPluginMethods) =!= True || ProjectName == "OSG-Staff"
+# Stop scheduling of all OSDF jobs (except OSG-Staff for debugging)
+# It should be enough to check WantTransferPluginMethods, but we might have
+# a bug when applying our image transforms, so include container_image and
+# orig_SingularityImage in the check.
+#NEGOTIATOR_JOB_CONSTRAINT = ( regexp("osdf|stash|pelican", WantTransferPluginMethods) || \
+#                              regexp("osdf|stash|pelican", container_image) || \
+#                              regexp("osdf|stash|pelican", orig_SingularityImage) \
+#                            ) =!= True || \
+#                            ProjectName == "OSG-Staff"
 
 # stop all scheduling except the OSG-Staff group for debugging
 #NEGOTIATOR_JOB_CONSTRAINT = ProjectName == "OSG-Staff"


### PR DESCRIPTION
@astroclark @jasoncpatton This is probably OSG AP specific, but note that we are seeing cases where `WantTransferPluginMethods` is not updated after we apply our image transforms. We have expanded the disabled OSDG job expression to catch those jobs.