### PR TITLE
ITB: Added system security check during glidein startup

### DIFF
--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=907
+OSG_GLIDEIN_VERSION=908
 #######################################################################
 
 

--- a/ospool-pilot/itb/pilot/check-system-security
+++ b/ospool-pilot/itb/pilot/check-system-security
@@ -73,9 +73,8 @@ pretty_name = os_info.get("PRETTY_NAME", f"{distro_id} {version_id}")
 kernel_raw = platform.release()
 kernel_tuple = parse_kernel_version(kernel_raw)
 
-print(f"System:  {pretty_name}")
-print(f"Kernel:  {kernel_raw}")
-print()
+print(f"CVE-2026-31431: System:  {pretty_name}")
+print(f"CVE-2026-31431: Kernel:  {kernel_raw}")
 
 # CVE-2026-31431
 patched = kernel_is_patched(distro_id, version_id, kernel_tuple) if kernel_tuple else None

--- a/ospool-pilot/itb/pilot/check-system-security
+++ b/ospool-pilot/itb/pilot/check-system-security
@@ -2,7 +2,7 @@
 
 import platform
 import re
-import socket
+import subprocess
 
 
 def get_os_info():
@@ -93,11 +93,25 @@ else:
         note = f"kernel {kernel_raw} < {fixed_str} — running runtime check"
     print(f"CVE-2026-31431: ({note})")
     try:
-        s = socket.socket(socket.AF_ALG, socket.SOCK_SEQPACKET, 0)
-        s.bind(("aead", "gcm(aes)"))
-        s.close()
-        print("CVE-2026-31431: VULNERABLE: algif_aead is reachable")
-    except FileNotFoundError:
-        print("CVE-2026-31431: OK: AEAD algorithm not available (module blocked)")
-    except OSError as e:
-        print(f"CVE-2026-31431: OK: {e}")
+        with open("/proc/cmdline") as f:
+            cmdline = f.read()
+    except OSError:
+        cmdline = ""
+    if "initcall_blacklist=algif_aead_init" in cmdline:
+        print("CVE-2026-31431: OK: algif_aead_init is blacklisted in kernel cmdline")
+    else:
+        try:
+            result = subprocess.run(
+                ["lsmod"], capture_output=True, text=True, check=True
+            )
+            loaded = any(
+                line.split()[0] == "algif_aead"
+                for line in result.stdout.splitlines()
+                if line.split()
+            )
+        except OSError:
+            loaded = False
+        if loaded:
+            print("CVE-2026-31431: VULNERABLE: algif_aead module is loaded")
+        else:
+            print("CVE-2026-31431: OK: algif_aead module is not loaded")

--- a/ospool-pilot/itb/pilot/check-system-security
+++ b/ospool-pilot/itb/pilot/check-system-security
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+import platform
+import re
+import socket
+
+
+def get_os_info():
+    info = {}
+    try:
+        with open("/etc/os-release") as f:
+            for line in f:
+                line = line.strip()
+                if "=" in line:
+                    key, _, value = line.partition("=")
+                    info[key] = value.strip('"')
+    except FileNotFoundError:
+        pass
+    return info
+
+
+def parse_kernel_version(release):
+    """Extract a version tuple from a kernel release string.
+
+    RHEL-family kernels (e.g. 4.18.0-553.120.1.el8_10.x86_64) return a
+    4-tuple (major, minor, patch, rhel_release) so the RHEL release number
+    (553 in the example) participates in comparisons — the upstream triple
+    4.18.0 never changes across Rocky/RHEL 8 errata.
+
+    All other kernels return a 3-tuple (major, minor, patch).
+    """
+    rhel_match = re.match(r"(\d+)\.(\d+)\.(\d+)-(\d+)\.\d+.*\.el\d", release)
+    if rhel_match:
+        return tuple(int(x) for x in rhel_match.groups())
+    match = re.match(r"(\d+)\.(\d+)\.(\d+)", release)
+    if match:
+        return tuple(int(x) for x in match.groups())
+    return None
+
+
+def kernel_tuple_str(t):
+    """Format a version tuple as a human-readable string (e.g. '4.18.0-553')."""
+    if len(t) == 4:
+        return f"{t[0]}.{t[1]}.{t[2]}-{t[3]}"
+    return ".".join(str(x) for x in t)
+
+
+# Minimum kernel version where CVE-2026-31431 is fixed, keyed by (distro_id, version_id).
+# Kernels at or above this version do not need the runtime socket test.
+# RHEL-family entries use a 4-tuple (major, minor, patch, rhel_release).
+CVE_2026_31431_FIXED = {
+    ("debian", "13"): (6, 12, 85),
+    #("rocky", "8"): (4, 18, 0, 554), placeholder
+}
+
+
+def kernel_is_patched(distro_id, version_id, kernel_tuple):
+    """Return True if patched, False if vulnerable, None if unknown distro/version."""
+    key = (distro_id.lower(), version_id)
+    if key not in CVE_2026_31431_FIXED:
+        return None
+    fixed = CVE_2026_31431_FIXED[key]
+    if len(fixed) != len(kernel_tuple):
+        return None
+    return kernel_tuple >= fixed
+
+
+os_info = get_os_info()
+distro_id = os_info.get("ID", "unknown")
+version_id = os_info.get("VERSION_ID", "unknown").split(".")[0]
+pretty_name = os_info.get("PRETTY_NAME", f"{distro_id} {version_id}")
+
+kernel_raw = platform.release()
+kernel_tuple = parse_kernel_version(kernel_raw)
+
+print(f"System:  {pretty_name}")
+print(f"Kernel:  {kernel_raw}")
+print()
+
+# CVE-2026-31431
+patched = kernel_is_patched(distro_id, version_id, kernel_tuple) if kernel_tuple else None
+
+if patched is True:
+    fixed_ver = CVE_2026_31431_FIXED[(distro_id.lower(), version_id)]
+    fixed_str = kernel_tuple_str(fixed_ver)
+    print(f"CVE-2026-31431: OK: kernel {kernel_raw} >= {fixed_str} (patched for {pretty_name})")
+else:
+    if patched is None:
+        note = "no fixed-version data for this distribution — running runtime check"
+    else:
+        fixed_ver = CVE_2026_31431_FIXED[(distro_id.lower(), version_id)]
+        fixed_str = kernel_tuple_str(fixed_ver)
+        note = f"kernel {kernel_raw} < {fixed_str} — running runtime check"
+    print(f"CVE-2026-31431: ({note})")
+    try:
+        s = socket.socket(socket.AF_ALG, socket.SOCK_SEQPACKET, 0)
+        s.bind(("aead", "gcm(aes)"))
+        s.close()
+        print("CVE-2026-31431: VULNERABLE: algif_aead is reachable")
+    except FileNotFoundError:
+        print("CVE-2026-31431: OK: AEAD algorithm not available (module blocked)")
+    except OSError as e:
+        print(f"CVE-2026-31431: OK: {e}")

--- a/ospool.osg-htc.org/development/frontend-template.xml
+++ b/ospool.osg-htc.org/development/frontend-template.xml
@@ -413,6 +413,9 @@
        <file absfname="/opt/osg-flock/tools/garbage_collection/garbage_collection" after_entry="True" after_group="False" const="True" executable="True" period="0" prefix="NOPREFIX" untar="False" wrapper="False">
           <untar_options cond_attr="TRUE"/>
        </file>
+      <file absfname="/opt/osg-flock/ospool-pilot/itb/pilot/check-system-security" after_entry="True" after_group="False" const="True" executable="True" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="False">
+         <untar_options cond_attr="TRUE"/>
+      </file>
       <file absfname="/opt/osg-flock/node-check/osgvo-node-validation" after_entry="True" after_group="False" const="True" executable="True" period="0" prefix="GLIDEIN_PS_" untar="False" wrapper="False">
          <untar_options cond_attr="TRUE"/>
       </file>


### PR DESCRIPTION
ITB. Adds a simple check for CVE-2026-31431, based on kernel version and mitigation test (only run if the kernel version test fails).

We will update the kernel patch list as vendor updates are released.

The check is not fatal, and will only log the results to the glidein log.