### PR TITLE
ITB: use an existing sif image for testing, not a converted docker image

### DIFF
--- a/ospool-pilot/itb/lib/ospool-lib
+++ b/ospool-pilot/itb/lib/ospool-lib
@@ -164,21 +164,21 @@ function http_download {
 
 
 function download_minimal_sif_image {
-    # downloads a small Alpine based sif image and sticks it into the image dir
+    # downloads a small sif image and sticks it into the image dir
     local arch=$(uname -m)
-    local cvmfs_alpine="/cvmfs/oasis.opensciencegrid.org/osg/projects/OSG-Staff/images/$arch/library__alpine__latest.sif"
+    local cvmfs_image="/cvmfs/oasis.opensciencegrid.org/osg/projects/OSG-Staff/images/$arch/htc__minimal__0.sif"
     local http_base="https://ospool-images-web.nrp-nautilus.io/v2"
     local image_dir="$work_dir/../images"
 
     # only download once
-    if [ -e $image_dir/gwms-alpine.sif ]; then
+    if [ -e $image_dir/htc__minimal__0.sif ]; then
         return 0
     fi
 
     # try cvmfs
-    if [ -e $cvmfs_alpine ]; then
-        if cp "$cvmfs_alpine" $image_dir/gwms-alpine.sif; then
-            echo "Copied from $cvmfs_alpine" >$image_dir/gwms-alpine.sif.log
+    if [ -e $cvmfs_image ]; then
+        if cp "$cvmfs_image" $image_dir/htc__minimal__0.sif; then
+            echo "Copied from $cvmfs_image" >$image_dir/htc__minimal__0.sif.log
             return 0
         fi
     fi
@@ -192,8 +192,8 @@ function download_minimal_sif_image {
         return 1
     fi
 
-    if ! http_download $image_dir/gwms-alpine.sif $http_base/$arch/htc__minimal__0/$latest &>"$image_dir/gwms-alpine.sif.log"; then
-        cat "$image_dir/gwms-alpine.sif.log" >&2
+    if ! http_download $image_dir/htc__minimal__0.sif $http_base/$arch/htc__minimal__0/$latest &>"$image_dir/htc__minimal__0.sif.log"; then
+        cat "$image_dir/htc__minimal__0.sif.log" >&2
         return 1
     fi
 
@@ -240,7 +240,7 @@ function check_singularity_sif_support {
 
     download_minimal_sif_image || return 1
 
-    output=$(timeout 60s $singularity_path exec $image_dir/gwms-alpine.sif /bin/true 2>&1)
+    output=$(timeout 60s $singularity_path exec $image_dir/htc__minimal__0.sif /bin/true 2>&1)
     ret=$?
 
     if [[ $ret != 0 ]]; then

--- a/ospool-pilot/itb/lib/ospool-lib
+++ b/ospool-pilot/itb/lib/ospool-lib
@@ -163,6 +163,44 @@ function http_download {
 }
 
 
+function download_minimal_sif_image {
+    # downloads a small Alpine based sif image and sticks it into the image dir
+    local arch=$(uname -m)
+    local cvmfs_alpine="/cvmfs/oasis.opensciencegrid.org/osg/projects/OSG-Staff/images/$arch/library__alpine__latest.sif"
+    local http_base="https://ospool-images-web.nrp-nautilus.io/v2"
+    local image_dir="$work_dir/../images"
+
+    # only download once
+    if [ -e $image_dir/gwms-alpine.sif ]; then
+        return 0
+    fi
+
+    # try cvmfs
+    if [ -e $cvmfs_alpine ]; then
+        if cp "$cvmfs_alpine" $image_dir/gwms-alpine.sif; then
+            echo "Copied from $cvmfs_alpine" >$image_dir/gwms-alpine.sif.log
+            return 0
+        fi
+    fi
+
+    # http. first, we have to determine the latest version of the selected image
+    echo "curl -s -S --insecure --max-time 60 --retry 0 --fail $http_base/$arch/htc__minimal__0/latest.txt"
+    latest=$(curl -s -S --insecure --max-time 60 --retry 0 --fail $http_base/$arch/htc__minimal__0/latest.txt); ret=$?
+    if [[ $ret != 0 || ! $latest ]]; then
+        my_warn "Unable to determine the latest sif for htc__minimal__0"
+        my_warn "curl returned $ret; output: $latest"
+        return 1
+    fi
+
+    if ! http_download $image_dir/gwms-alpine.sif $http_base/$arch/htc__minimal__0/$latest &>"$image_dir/gwms-alpine.sif.log"; then
+        cat "$image_dir/gwms-alpine.sif.log" >&2
+        return 1
+    fi
+
+    return 0
+}
+
+
 function check_singularity_sif_support {
     # Return 0 if singularity can directly run a .sif file without having to
     # unpack it into a temporary sandbox first, nonzero otherwise.
@@ -172,14 +210,6 @@ function check_singularity_sif_support {
 
     # Grab an alpine image from somewhere; ok to download each time since
     # it's like 3 megs
-    local arch=$(uname -m)
-    local cvmfs_alpine="/cvmfs/oasis.opensciencegrid.org/osg/projects/OSG-Staff/images/$arch/library__alpine__latest.sif"
-    # temporary seperation until we decide on longterm multi-arch hosting
-    if [ "X$arch" = "Xx86_64" ]; then
-        local static_registry_alpine="docker://ospool-static-registry.osg.chtc.io/alpine:latest"
-    else
-        local static_registry_alpine="docker://hub.opensciencegrid.org/htc/minimal:0"
-    fi
     local work_dir=$(gconfig_get GLIDEIN_WORK_DIR)
     local image_dir="$work_dir/../images"
     local has_singularity=$(gconfig_get HAS_SINGULARITY)
@@ -208,19 +238,7 @@ function check_singularity_sif_support {
         return 1
     fi
 
-    # only download once
-    if [ ! -e $image_dir/gwms-alpine.sif.log ]; then
-        (cp "$cvmfs_alpine" $image_dir/gwms-alpine.sif ||
-             timeout 60s $singularity_path pull --force $image_dir/gwms-alpine.sif "$static_registry_alpine" ||
-             my_warn "All sources failed - could not create gwms-alpine.sif"
-        ) &> $image_dir/gwms-alpine.sif.log
-    fi
-
-    # did the download fail
-    if [ ! -e $image_dir/gwms-alpine.sif ]; then
-        cat "$image_dir/gwms-alpine.sif.log" >&2
-        return 1
-    fi
+    download_minimal_sif_image || return 1
 
     output=$(timeout 60s $singularity_path exec $image_dir/gwms-alpine.sif /bin/true 2>&1)
     ret=$?

--- a/ospool-pilot/itb/lib/ospool-lib
+++ b/ospool-pilot/itb/lib/ospool-lib
@@ -220,12 +220,6 @@ function check_singularity_sif_support {
         return 1
     fi
 
-    # do not allow sif images at Nebraska - the container-in-container is not working
-    GLIDEIN_Site=$(gconfig_get GLIDEIN_Site)
-    if (echo "$GLIDEIN_Site" | egrep -i "Nebraska") >/dev/null 2>&1; then
-        return 1
-    fi
-
     # if singularity is not in the path at this point (detection happens later),
     # we have to assume SIF support
     if ! ($singularity_path --version) >/dev/null 2>&1; then

--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=910
+OSG_GLIDEIN_VERSION=911
 #######################################################################
 
 


### PR DESCRIPTION
Downloads a very small SIF image from CVMFS or https. There is no reason for Pelican here as the image is small, and the test should execute independently of Pelican being available.

The old approach with a Docker image could fail on some sites due the Docker->SIF conversion on certain filesystems.
