### PR TITLE
Pelican timeout / lower speedlimit for default image downloads

### DIFF
--- a/ospool-pilot/itb/lib/ospool-lib
+++ b/ospool-pilot/itb/lib/ospool-lib
@@ -109,8 +109,9 @@ function osdf_download {
     done
 
     if [ "x$PELICAN" != "x" -a -e $PELICAN ]; then
+        # Make sure this commands timeouts/stops in case of slow transfers. 1 Mb/s to match the curl below.
         rm -rf "$dest" \
-            && $PELICAN object get "$src" "$dest_sif"
+            && PELICAN_CLIENT_MINIMUMDOWNLOADSPEED=1000000 timeout 180s $PELICAN object get "$src" "$dest_sif"
         ret=$?
     else
         warn "pelican is not available"

--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=918
+OSG_GLIDEIN_VERSION=919
 #######################################################################
 
 

--- a/ospool-pilot/main/lib/ospool-lib
+++ b/ospool-pilot/main/lib/ospool-lib
@@ -109,8 +109,9 @@ function osdf_download {
     done
 
     if [ "x$PELICAN" != "x" -a -e $PELICAN ]; then
+        # Make sure this commands timeouts/stops in case of slow transfers. 1 Mb/s to match the curl below.
         rm -rf "$dest" \
-            && $PELICAN object get "$src" "$dest_sif"
+            && PELICAN_CLIENT_MINIMUMDOWNLOADSPEED=1000000 timeout 180s $PELICAN object get "$src" "$dest_sif"
         ret=$?
     else
         warn "pelican is not available"

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=859
+OSG_GLIDEIN_VERSION=860
 #######################################################################
 
 


### PR DESCRIPTION
This is to ensure glideins are not hitting the script timeout (600s) and terminate the full glidein, just because a slow cache. Example:

```
default-image.q730yo: OK
Signature OK for client:default-image.q730yo.
Linking helper(s) from /tmp/glide_wF4JYB/client/ospool-lib
INFO  Starting download of default image (htc__rocky__8)
INFO  Using Pelican to download pelican://osg-htc.org/ospool/images/v2/x86_64/htc__rocky__8/20260526T053001Z.sif
=== Validation error in /tmp/glide_wF4JYB/client/default-image ===
Command /tmp/glide_wF4JYB/client/default-image killed by timeout (600 s)
Fri Aug  7 01:17:15 PDT 2026 Error running '/tmp/glide_wF4JYB/client/default-image'
     The test script did not produce an XML file. No further information available.
```