### PR TITLE
Default image timeout, again

### DIFF
--- a/ospool-pilot/itb/lib/ospool-lib
+++ b/ospool-pilot/itb/lib/ospool-lib
@@ -111,7 +111,7 @@ function osdf_download {
     if [ "x$PELICAN" != "x" -a -e $PELICAN ]; then
         # Make sure this commands timeouts/stops in case of slow transfers. 1 Mb/s to match the curl below.
         rm -rf "$dest" \
-            && PELICAN_CLIENT_MINIMUMDOWNLOADSPEED=1000000 timeout 300s $PELICAN object get "$src" "$dest_sif"
+            && PELICAN_CLIENT_MINIMUMDOWNLOADSPEED=1000000 timeout 240s $PELICAN object get "$src" "$dest_sif"
         ret=$?
     else
         warn "pelican is not available"
@@ -140,10 +140,10 @@ function http_download {
     local dest_sif="${dest%.sif}.sif"
 
     if command -v curl >/dev/null 2>&1; then
-        curl --silent --verbose --show-error --fail --location --connect-timeout 30 --speed-limit 1024 -o "$dest_sif" "$src"
+        timeout 240s curl --silent --verbose --show-error --fail --location --connect-timeout 30 --speed-limit 1024 -o "$dest_sif" "$src"
         ret=$?
     elif command -v wget >/dev/null 2>&1; then
-        wget -nv --timeout=30 --tries=1 -O "$dest_sif" "$src"
+        timeout 240s wget -nv --timeout=30 --tries=1 -O "$dest_sif" "$src"
         ret=$?
     else
         warn "Neither curl nor wget are available"

--- a/ospool-pilot/itb/lib/ospool-lib
+++ b/ospool-pilot/itb/lib/ospool-lib
@@ -111,7 +111,7 @@ function osdf_download {
     if [ "x$PELICAN" != "x" -a -e $PELICAN ]; then
         # Make sure this commands timeouts/stops in case of slow transfers. 1 Mb/s to match the curl below.
         rm -rf "$dest" \
-            && PELICAN_CLIENT_MINIMUMDOWNLOADSPEED=1000000 timeout 180s $PELICAN object get "$src" "$dest_sif"
+            && PELICAN_CLIENT_MINIMUMDOWNLOADSPEED=1000000 timeout 300s $PELICAN object get "$src" "$dest_sif"
         ret=$?
     else
         warn "pelican is not available"

--- a/ospool-pilot/itb/pilot/advertise-base
+++ b/ospool-pilot/itb/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=919
+OSG_GLIDEIN_VERSION=920
 #######################################################################
 
 

--- a/ospool-pilot/itb/pilot/default-image
+++ b/ospool-pilot/itb/pilot/default-image
@@ -23,7 +23,7 @@ function pull_default_container_image {
 
     #
     # pull the image into a Singularity SIF file
-    # Attempt a download via Pelican first, then HTTP, then a pull from Harbor
+    # Attempt a download via Pelican first, then HTTP
     #
     IMAGE_NAME=$(echo "$SELECTED_IMAGE" | sed 's;[:/];__;g')
     IMAGE_PATH=$PWD/images/$IMAGE_NAME.sif
@@ -31,7 +31,6 @@ function pull_default_container_image {
     HTTP_BASE=https://ospool-images-web.nrp-nautilus.io/v2
     # PELICAN_BASE=pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/images/v2
     PELICAN_BASE=pelican://osg-htc.org/ospool/images/v2
-    HARBOR_URL=docker://hub.opensciencegrid.org/$SELECTED_IMAGE
 
     # first, we have to do a HTTP call to get the latest version of the selected image
     LATEST=$(curl -s -S --insecure --max-time 60 --retry 0 --fail $HTTP_BASE/$arch/$IMAGE_NAME/latest.txt); ret=$?
@@ -51,29 +50,16 @@ function pull_default_container_image {
         info "Pelican download successful"
         download_ok=1
         advertise OSG_DEFAULT_SINGULARITY_IMAGE_SOURCE "OSDF" "S"
-    elif [[ $ret = 124 ]]; then
-        # the transfer timed out / was too slow - the other download methods
-        # are unlikely to do any better, so give up and let the caller fall
-        # back to a CVMFS image
-        my_warn "Pelican download timed out (exit $ret) - skipping the HTTP and registry fallbacks"
-        return 1
     else
         my_warn "Pelican download failed (exit $ret)"
         info "Using HTTP to download $HTTP_BASE/$URL_PATH"
-        if http_download "$IMAGE_PATH" "$HTTP_BASE/$URL_PATH" &>"$IMAGE_PATH.log"; then
+        http_download "$IMAGE_PATH" "$HTTP_BASE/$URL_PATH" &>"$IMAGE_PATH.log"; ret=$?
+        if [[ $ret = 0 ]]; then
             info "HTTP download successful"
             download_ok=1
             advertise OSG_DEFAULT_SINGULARITY_IMAGE_SOURCE "HTTP" "S"
         else
-            my_warn "HTTP download failed"
-            info "Downloading from Docker registry at $HARBOR_URL"
-            if singularity pull --force "$IMAGE_PATH" "$HARBOR_URL" &>"$IMAGE_PATH.log"; then
-                info "Registry download successful"
-                download_ok=1
-                advertise OSG_DEFAULT_SINGULARITY_IMAGE_SOURCE "Registry" "S"
-            else
-                my_warn "Registry download failed"
-            fi
+            my_warn "HTTP download failed (exit $ret)"
         fi
     fi
 
@@ -85,7 +71,7 @@ function pull_default_container_image {
         advertise OSG_DEFAULT_SINGULARITY_IMAGE "$IMAGE_PATH" "S"
         return 0
     else
-        my_warn "Failed to pull $SELECTED_IMAGE via http/pelican/registry"
+        my_warn "Failed to pull $SELECTED_IMAGE"
         return 1
     fi
 }

--- a/ospool-pilot/itb/pilot/default-image
+++ b/ospool-pilot/itb/pilot/default-image
@@ -46,12 +46,19 @@ function pull_default_container_image {
     download_ok=0
     info "Starting download of default image ($IMAGE_NAME)"
     info "Using Pelican to download $PELICAN_BASE/$URL_PATH"
-    if osdf_download "$IMAGE_PATH" "$PELICAN_BASE/$URL_PATH" &>"$IMAGE_PATH.log"; then
+    osdf_download "$IMAGE_PATH" "$PELICAN_BASE/$URL_PATH" &>"$IMAGE_PATH.log"; ret=$?
+    if [[ $ret = 0 ]]; then
         info "Pelican download successful"
         download_ok=1
         advertise OSG_DEFAULT_SINGULARITY_IMAGE_SOURCE "OSDF" "S"
+    elif [[ $ret = 124 ]]; then
+        # the transfer timed out / was too slow - the other download methods
+        # are unlikely to do any better, so give up and let the caller fall
+        # back to a CVMFS image
+        my_warn "Pelican download timed out (exit $ret) - skipping the HTTP and registry fallbacks"
+        return 1
     else
-        my_warn "Pelican download failed"
+        my_warn "Pelican download failed (exit $ret)"
         info "Using HTTP to download $HTTP_BASE/$URL_PATH"
         if http_download "$IMAGE_PATH" "$HTTP_BASE/$URL_PATH" &>"$IMAGE_PATH.log"; then
             info "HTTP download successful"
@@ -124,7 +131,7 @@ function determine_default_container_image {
     # if everything else fails, use EL8/EL9
     if [ "x$SELECTED_IMAGE" = "x" ]; then
         if [ "x$CUDA_VISIBLE_DEVICES" != "x" -a "x$CUDA_VISIBLE_DEVICES" != "x10000" ]; then
-            SELECTED_IMAGE="htc/rocky:8-cuda-11.0.3"
+            SELECTED_IMAGE="htc/rocky:9-cuda-12.6.0"
         else
             SELECTED_IMAGE="htc/rocky:9"
         fi

--- a/ospool-pilot/main/lib/ospool-lib
+++ b/ospool-pilot/main/lib/ospool-lib
@@ -111,7 +111,7 @@ function osdf_download {
     if [ "x$PELICAN" != "x" -a -e $PELICAN ]; then
         # Make sure this commands timeouts/stops in case of slow transfers. 1 Mb/s to match the curl below.
         rm -rf "$dest" \
-            && PELICAN_CLIENT_MINIMUMDOWNLOADSPEED=1000000 timeout 300s $PELICAN object get "$src" "$dest_sif"
+            && PELICAN_CLIENT_MINIMUMDOWNLOADSPEED=1000000 timeout 240s $PELICAN object get "$src" "$dest_sif"
         ret=$?
     else
         warn "pelican is not available"
@@ -140,10 +140,10 @@ function http_download {
     local dest_sif="${dest%.sif}.sif"
 
     if command -v curl >/dev/null 2>&1; then
-        curl --silent --verbose --show-error --fail --location --connect-timeout 30 --speed-limit 1024 -o "$dest_sif" "$src"
+        timeout 240s curl --silent --verbose --show-error --fail --location --connect-timeout 30 --speed-limit 1024 -o "$dest_sif" "$src"
         ret=$?
     elif command -v wget >/dev/null 2>&1; then
-        wget -nv --timeout=30 --tries=1 -O "$dest_sif" "$src"
+        timeout 240s wget -nv --timeout=30 --tries=1 -O "$dest_sif" "$src"
         ret=$?
     else
         warn "Neither curl nor wget are available"

--- a/ospool-pilot/main/lib/ospool-lib
+++ b/ospool-pilot/main/lib/ospool-lib
@@ -111,7 +111,7 @@ function osdf_download {
     if [ "x$PELICAN" != "x" -a -e $PELICAN ]; then
         # Make sure this commands timeouts/stops in case of slow transfers. 1 Mb/s to match the curl below.
         rm -rf "$dest" \
-            && PELICAN_CLIENT_MINIMUMDOWNLOADSPEED=1000000 timeout 180s $PELICAN object get "$src" "$dest_sif"
+            && PELICAN_CLIENT_MINIMUMDOWNLOADSPEED=1000000 timeout 300s $PELICAN object get "$src" "$dest_sif"
         ret=$?
     else
         warn "pelican is not available"

--- a/ospool-pilot/main/pilot/advertise-base
+++ b/ospool-pilot/main/pilot/advertise-base
@@ -31,7 +31,7 @@
 # OSG_GLIDEIN_VERSION is an ever-increasing version of the glideins.
 # This can be used by negotiators or users, for example to match
 # against a glidein newer than some base with new features.
-OSG_GLIDEIN_VERSION=860
+OSG_GLIDEIN_VERSION=861
 #######################################################################
 
 

--- a/ospool-pilot/main/pilot/default-image
+++ b/ospool-pilot/main/pilot/default-image
@@ -23,7 +23,7 @@ function pull_default_container_image {
 
     #
     # pull the image into a Singularity SIF file
-    # Attempt a download via Pelican first, then HTTP, then a pull from Harbor
+    # Attempt a download via Pelican first, then HTTP
     #
     IMAGE_NAME=$(echo "$SELECTED_IMAGE" | sed 's;[:/];__;g')
     IMAGE_PATH=$PWD/images/$IMAGE_NAME.sif
@@ -31,7 +31,6 @@ function pull_default_container_image {
     HTTP_BASE=https://ospool-images-web.nrp-nautilus.io/v2
     # PELICAN_BASE=pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/images/v2
     PELICAN_BASE=pelican://osg-htc.org/ospool/images/v2
-    HARBOR_URL=docker://hub.opensciencegrid.org/$SELECTED_IMAGE
 
     # first, we have to do a HTTP call to get the latest version of the selected image
     LATEST=$(curl -s -S --insecure --max-time 60 --retry 0 --fail $HTTP_BASE/$arch/$IMAGE_NAME/latest.txt); ret=$?
@@ -51,29 +50,16 @@ function pull_default_container_image {
         info "Pelican download successful"
         download_ok=1
         advertise OSG_DEFAULT_SINGULARITY_IMAGE_SOURCE "OSDF" "S"
-    elif [[ $ret = 124 ]]; then
-        # the transfer timed out / was too slow - the other download methods
-        # are unlikely to do any better, so give up and let the caller fall
-        # back to a CVMFS image
-        my_warn "Pelican download timed out (exit $ret) - skipping the HTTP and registry fallbacks"
-        return 1
     else
         my_warn "Pelican download failed (exit $ret)"
         info "Using HTTP to download $HTTP_BASE/$URL_PATH"
-        if http_download "$IMAGE_PATH" "$HTTP_BASE/$URL_PATH" &>"$IMAGE_PATH.log"; then
+        http_download "$IMAGE_PATH" "$HTTP_BASE/$URL_PATH" &>"$IMAGE_PATH.log"; ret=$?
+        if [[ $ret = 0 ]]; then
             info "HTTP download successful"
             download_ok=1
             advertise OSG_DEFAULT_SINGULARITY_IMAGE_SOURCE "HTTP" "S"
         else
-            my_warn "HTTP download failed"
-            info "Downloading from Docker registry at $HARBOR_URL"
-            if singularity pull --force "$IMAGE_PATH" "$HARBOR_URL" &>"$IMAGE_PATH.log"; then
-                info "Registry download successful"
-                download_ok=1
-                advertise OSG_DEFAULT_SINGULARITY_IMAGE_SOURCE "Registry" "S"
-            else
-                my_warn "Registry download failed"
-            fi
+            my_warn "HTTP download failed (exit $ret)"
         fi
     fi
 
@@ -85,7 +71,7 @@ function pull_default_container_image {
         advertise OSG_DEFAULT_SINGULARITY_IMAGE "$IMAGE_PATH" "S"
         return 0
     else
-        my_warn "Failed to pull $SELECTED_IMAGE via http/pelican/registry"
+        my_warn "Failed to pull $SELECTED_IMAGE"
         return 1
     fi
 }

--- a/ospool-pilot/main/pilot/default-image
+++ b/ospool-pilot/main/pilot/default-image
@@ -46,12 +46,19 @@ function pull_default_container_image {
     download_ok=0
     info "Starting download of default image ($IMAGE_NAME)"
     info "Using Pelican to download $PELICAN_BASE/$URL_PATH"
-    if osdf_download "$IMAGE_PATH" "$PELICAN_BASE/$URL_PATH" &>"$IMAGE_PATH.log"; then
+    osdf_download "$IMAGE_PATH" "$PELICAN_BASE/$URL_PATH" &>"$IMAGE_PATH.log"; ret=$?
+    if [[ $ret = 0 ]]; then
         info "Pelican download successful"
         download_ok=1
         advertise OSG_DEFAULT_SINGULARITY_IMAGE_SOURCE "OSDF" "S"
+    elif [[ $ret = 124 ]]; then
+        # the transfer timed out / was too slow - the other download methods
+        # are unlikely to do any better, so give up and let the caller fall
+        # back to a CVMFS image
+        my_warn "Pelican download timed out (exit $ret) - skipping the HTTP and registry fallbacks"
+        return 1
     else
-        my_warn "Pelican download failed"
+        my_warn "Pelican download failed (exit $ret)"
         info "Using HTTP to download $HTTP_BASE/$URL_PATH"
         if http_download "$IMAGE_PATH" "$HTTP_BASE/$URL_PATH" &>"$IMAGE_PATH.log"; then
             info "HTTP download successful"


### PR DESCRIPTION
@osg-cat FYI

Some sites are still timing out on default-image (hitting the GWMS script timeout of 600s).

This change handles a timeout on the Pelican download as a short-circuit. After timeouts, http and registry pull will not be attempted.

Increased the Pelican timeout to 300s.

Also updated the default GPU image on ITB. For some reason, it was out of sync.